### PR TITLE
Add aps:QueryMetrics to Grafana role permissions

### DIFF
--- a/cloud/aws/templates/aws_oidc/monitoring.tf
+++ b/cloud/aws/templates/aws_oidc/monitoring.tf
@@ -67,6 +67,7 @@ resource "aws_iam_policy" "civiform_monitoring_role_policy" {
             "aps:ListRuleGroupsNamespaces",
             "aps:PutAlertManagerDefinition",
             "aps:PutRuleGroupsNamespace",
+            "aps:QueryMetrics",
             "aps:TagResource",
             "aps:UntagResource",
             "aps:CreateLoggingConfiguration",


### PR DESCRIPTION
Needed for Grafana to query metrics from prometheus