### PR TITLE
Pipe `ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS` in AWS deployment

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -117,6 +117,7 @@ module "civiform_server_container_def" {
     ADFS_ADDITIONAL_SCOPES                    = var.adfs_additional_scopes
     AD_GROUPS_ATTRIBUTE_NAME                  = var.ad_groups_attribute_name
     ADFS_GLOBAL_ADMIN_GROUP                   = var.adfs_admin_group
+    ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS      = var.allow_civiform_admin_access_programs
 
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled
     CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET          = var.civiform_api_keys_ban_global_subnet

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -317,3 +317,9 @@ variable "civiform_server_metrics_enabled" {
   description = "Whether to enable exporting server metrics on the /metrics route."
   default     = false
 }
+
+variable "allow_civiform_admin_access_programs" {
+  type        = bool
+  description = "Whether CiviForm admins can view program applications, similar to Program Admins."
+  default     = false
+}

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -158,5 +158,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }
 }


### PR DESCRIPTION
That variable controls whether CiviForm can see applications for a given program. Feature already implemented in CiviForm but we don't propagated in AWS deployment scripts. So entities who use our deploy scripts can't set it.