### PR TITLE
Update docker image to fix aws-cli, update doctor to properly report AWS info from within docker.

### DIFF
--- a/cloud/cloud.Dockerfile
+++ b/cloud/cloud.Dockerfile
@@ -17,9 +17,4 @@ COPY --from=amazon/aws-cli:2.8.2 /aws /aws
 RUN /bin/sh -c set -o pipefail && apt-get update && \
 	apt-get upgrade --yes && apt-get install --yes bash python3 git
 
-
-#apk update && \
-#    apk add --upgrade apk-tools && apk upgrade --available && \
-#    apk add --no-cache --update bash python3 git less groff
-
 COPY ./cloud/ cloud/

--- a/cloud/cloud.Dockerfile
+++ b/cloud/cloud.Dockerfile
@@ -4,8 +4,8 @@
 # workaround uses an aarch64 (arm64) image instead when an optional platform argument is set to arm64.
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
-FROM eclipse-temurin:11.0.16_8-jre-alpine as amd64
-FROM bellsoft/liberica-openjre-alpine:11.0.16-8 as arm64
+FROM eclipse-temurin:11.0.16_8-jre as amd64
+FROM bellsoft/liberica-openjre-debian:11.0.16-8 as arm64
 
 FROM ${TARGETARCH}
 
@@ -14,8 +14,12 @@ COPY --from=amazon/aws-cli:2.8.2 /usr/local /usr/local
 COPY --from=amazon/aws-cli:2.8.2 /aws /aws
 # TODO(#3222): Add Azure CLI and make sure It works with arm64.
 
-RUN /bin/sh -c set -o pipefail && apk update && \
-    apk add --upgrade apk-tools && apk upgrade --available && \
-    apk add --no-cache --update bash python3 git less groff
+RUN /bin/sh -c set -o pipefail && apt-get update && \
+	apt-get upgrade --yes && apt-get install --yes bash python3 git
+
+
+#apk update && \
+#    apk add --upgrade apk-tools && apk upgrade --available && \
+#    apk add --no-cache --update bash python3 git less groff
 
 COPY ./cloud/ cloud/

--- a/cloud/shared/bin/doctor.py
+++ b/cloud/shared/bin/doctor.py
@@ -90,7 +90,7 @@ class AwsCliCheck(Check):
         return self._get_cloud_provider() not in ['aws', 'azure']
 
     def is_ok(self):
-        return self._check_command_succeeds(["aws", "help"])
+        return self._check_command_succeeds(["aws", "--version"])
 
 
 class AzureCliCheck(Check):
@@ -168,10 +168,13 @@ class AwsLoginCheck(Check):
         return self._get_cloud_provider() not in ['aws', 'azure']
 
     def is_ok(self):
-        output = self._get_command_output(["aws", "configure", "list-profiles"])
+        output = self._get_command_output(["aws", "sts", "get-caller-identity"])
 
-        # the default profile will be present if they are logged in
-        return 'default' in output
+        # If AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not set, the above
+        # command will print nothing to stdout and an error message to stderr.
+        # If they are set, a json object with the following keys will be
+        # printed to stdout.
+        return 'UserId' in output and 'Account' in output and 'Arn' in output
 
 
 class AzureLoginCheck(Check):


### PR DESCRIPTION
## Docker image changes

The aws cli executable dynamically links against shared objects that are not included in alpine linux (build with musl instead of glibc).  Update the docker image to build from non-alpine varients.

Alternatives considered:

1. Adding gcompat to the apk add list.  This did not resolve the issue because aws-cli still linked against
   missing shared objects.
1. Add missing shared objects manually like in
   aws/aws-cli#4685 (comment).
   This approached seems very brittle so I opted to use non-alpine
   images instead.

Resolves https://github.com/civiform/civiform/issues/3508#issuecomment-1275373266.

## Doctor changes

1. `aws help` requires groff, switch the command to `aws --version`.
2. `aws configure list-profiles` does not work when only setting the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env variables.  Update check to call `aws sts get-caller-identity` instead.

Addresses some aspects of https://github.com/civiform/civiform/issues/3544.