### PR TITLE
Add rover command

### DIFF
--- a/cloud/cloud.Dockerfile
+++ b/cloud/cloud.Dockerfile
@@ -10,6 +10,7 @@ FROM bellsoft/liberica-openjre-debian:11.0.16-8 as arm64
 FROM ${TARGETARCH}
 
 COPY --from=hashicorp/terraform:1.3.3 /bin/terraform /usr/local/bin/
+COPY --from=im2nguyen/rover:v0.3.3 /bin/rover /usr/local/bin/
 COPY --from=amazon/aws-cli:2.8.4 /usr/local /usr/local
 COPY --from=amazon/aws-cli:2.8.4 /aws /aws
 # TODO(#3222): Add Azure CLI and make sure It works with arm64.

--- a/cloud/shared/bin/rover.py
+++ b/cloud/shared/bin/rover.py
@@ -1,0 +1,19 @@
+"""
+Run rover.
+"""
+
+import subprocess
+from typing import List
+from cloud.shared.bin.lib.config_loader import ConfigLoader
+
+
+def run(config: ConfigLoader, params: List[str]):
+    td = config.get_template_dir()
+    subprocess.check_call(
+        [
+            "rover",
+            f"-workingDir=/{td}",
+            f"-tfBackendConfig=/{td}/backend_vars",
+            f"-tfVarsFile=/{td}/setup.auto.tfvars",
+        ]
+    )

--- a/cloud/shared/bin/rover.py
+++ b/cloud/shared/bin/rover.py
@@ -13,7 +13,7 @@ def run(config: ConfigLoader, params: List[str]):
         [
             "rover",
             f"-workingDir=/{td}",
-            f"-tfBackendConfig=/{td}/backend_vars",
-            f"-tfVarsFile=/{td}/setup.auto.tfvars",
+            f"-tfVarsFile=/{td}/{config.tfvars_filename}",
+            f"-tfBackendConfig=/{td}/{config.backend_vars_filename}",
         ]
     )


### PR DESCRIPTION
This adds support for visualizing the terraform config via https://github.com/im2nguyen/rover.

Requires updating the docker-compose files in the civiform-config repo to access the rover webserver: https://github.com/civiform/civiform-deploy/pull/29