### PR TITLE
Do not assume the host running the deploy tool is the same host used to access pgadmin web UI

### DIFF
--- a/cloud/aws/bin/pgadmin.py
+++ b/cloud/aws/bin/pgadmin.py
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.request
 
 from enum import Enum
-from typing import Callable
+from typing import Callable, List
 
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib.config_loader import ConfigLoader
@@ -43,6 +43,16 @@ def run(config: ConfigLoader):
 
 def _get_cidr_list() -> str:
     """Runs the CIDRInputStateMachine until the end state is reached."""
+    print(
+        "REQUIRED: configure IPv4 CIDR allow-list for pgadmin. The public IP of the host running the\n"
+        "web browser used to access pgadmin is required to be covered by a CIDR block in the list.\n\n"
+        "The public IP of the host running this tool is optional and allows the tool to wait until\n"
+        "pgadmin is available to print out connection information. This wait is cancellable. If the\n"
+        "tool is able to auto-detect its public IP, it will add it to the allow-list by default.\n\n"
+        "Visit https://checkip.amazonaws.com to find the public IP of a host running a web browser.\n"
+        "To add just a single IP to the allow-list, add a CIDR block like '172.0.0.1/32'.\n"
+    )
+
     sm = CIDRInputStateMachine(_detect_public_ip)
     user_input = ""
     while True:
@@ -55,7 +65,7 @@ def _get_cidr_list() -> str:
 
 def _detect_public_ip() -> str:
     try:
-        with urllib.request.urlopen("https://checkip.amazonaws.com/",
+        with urllib.request.urlopen("https://checkip.amazonaws.com",
                                     timeout=3) as response:
             # response contains a newline
             return response.read().decode("ascii").strip()
@@ -112,7 +122,8 @@ class CIDRInputStateMachine:
     State machine for getting a user-input list of CIDR blocks.
 
     Instantiate the class with a function that returns the public IP
-    of the host. The CIDR block list will default to the detected IP.
+    of the host. If the function returns a non-empty string, the user
+    will be asked if they would like to add the IP to the allow-list.
     Use a function that returns the empty string to disable this feature.
 
     After instantiating the class, call the next() function in a loop.
@@ -123,17 +134,23 @@ class CIDRInputStateMachine:
     Terraform expects. cidrs() returns an empty string if the state
     machine has not terminated.
 
-           |>-------------------------------IP found----------------------->|
-           |                                                                v
-    -> DETECT_IP --IP not found--> SET_VALIDATE_FORMAT --valid list--> ACCEPT_LIST --yes--> DONE
-                                    ^               |                       |
-                                    |--invalid list<|                       |
-                                    |                                       |
-                                    ^-------------------------no-----------<|
+           |>--IP found--> ADD_DETECTED_IP --yes--> APPEND_VALIDATE_FORMAT --|
+           |                          |              |                       |
+           |                          no        invalid list             valid list
+           |                          |              |                       |
+           |                          v              v                       v
+    -> DETECT_IP ---IP not found---> SET_VALIDATE_FORMAT ---valid list---> ACCEPT_LIST --yes--> DONE
+                                      ^              |                       |
+                                      |-invalid list<|                       |
+                                      |                                      |
+                                      ^-------------------------no----------<|
     """
 
     State = Enum(
-        'State', ['DETECT_IP', 'SET_VALIDATE_FORMAT', 'ACCEPT_LIST', 'DONE'])
+        'State', [
+            'DETECT_IP', 'ADD_DETECTED_IP', 'APPEND_VALIDATE_FORMAT',
+            'SET_VALIDATE_FORMAT', 'ACCEPT_LIST', 'DONE'
+        ])
     # Regexp is from cloud/aws/modules/pgadmin/variables.tf.
     valid_cidr_re = re.compile(
         "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))$")
@@ -141,54 +158,90 @@ class CIDRInputStateMachine:
     def __init__(self, detect_ip_func: PublicIPDetector):
         self._detect_ip = detect_ip_func
         self._state = self.State.DETECT_IP
+        self._ip = ""
         self._cidrs = ""
 
     def next(self, user_input: UserInput) -> UserPrompt:
-        # State transition helpers.
-        def goto_input_list():
-            self._cidrs = ""
-            self._state = self.State.SET_VALIDATE_FORMAT
-            return "REQUIRED: input a comma-separated list of IPv4 CIDR blocks that should have access to the pgadmin service.\n> "
+        input_blocks_msg = "Input a comma-separated list of CIDR blocks to add to the allow-list:\n> "
 
-        def goto_accept_list(formatted_cidrs):
-            self._cidrs = formatted_cidrs
+        def process_input(input: str) -> str:
+            blocks, errors = CIDRInputStateMachine._parse_blocks(input)
+            if errors != "":
+                return f"ERROR: found invalid CIDR blocks:\n{errors}\nRe-enter CIDR blocks:\n> "
+            if len(blocks) == 0:
+                return f"ERROR: allow-list must not be empty.\nRe-enter CIDR blocks:\n> "
+
+            self._cidrs = CIDRInputStateMachine._format_blocks(blocks)
             self._state = self.State.ACCEPT_LIST
-            return f"Parsed list: {formatted_cidrs}. Accept? (anything entered other than 'y' will trigger list re-entry) "
+            return f"Allow-list: {self._cidrs}.\nAccept? (anything entered other than 'y' triggers list re-entry) > "
 
         # State transition logic.
         s = self._state
         if s == self.State.DETECT_IP:
             ip = self._detect_ip()
-            if ip == "":
-                return goto_input_list()
+            if ip != "":
+                self._ip = ip
+                self._state = self.State.ADD_DETECTED_IP
+                return f"Detected IP of the host running the deploy tool: {ip}\nAdd to allow-list? (anything entered other than 'y' is a no) > "
             else:
-                return "Public IP detection sucessful. Defaulting pgadmin IPv4 CIDR block allowlist to found IP.\n" + goto_accept_list(
-                    f'["{ip}/32"]')
-        elif s == self.State.SET_VALIDATE_FORMAT:
-            # Validate each block in list.
-            errors = ""
-            blocks = [x.strip() for x in user_input.split(",")]
-            for b in blocks:
-                if self.valid_cidr_re.fullmatch(b) == None:
-                    errors += f"  {b}\n"
-            if errors != "":
-                return "ERROR: found invalid CIDR blocks:\n" + errors + "Re-enter CIDR blocks:\n> "
+                self._state = self.State.SET_VALIDATE_FORMAT
+                return f"Unable to detect IP of the host running the deploy tool.\n{input_blocks_msg}"
 
-            # Terraform expects lists in the `["item1", "item2", ..., "itemN"]` format:
-            # https://developer.hashicorp.com/terraform/language/values/variables#variables-on-the-command-line
-            #
-            # Notably, single quotes are not valid. Strings in lists formatted in f-strings are wrapped in single
-            # quotes so we need to replace them with double quotes.
-            return goto_accept_list(f"{blocks}".replace("'", '"'))
+        elif s == self.State.ADD_DETECTED_IP:
+            if user_input == "y":
+                self._state = self.State.APPEND_VALIDATE_FORMAT
+                return f"IP added. {input_blocks_msg}"
+            else:
+                self._ip = ""
+                self._state = self.State.SET_VALIDATE_FORMAT
+                return f"Ignoring IP. {input_blocks_msg}"
+
+        elif s == self.State.APPEND_VALIDATE_FORMAT:
+            return process_input(f"{self._ip}/32,{user_input}")
+
+        elif s == self.State.SET_VALIDATE_FORMAT:
+            return process_input(user_input)
+
         elif s == self.State.ACCEPT_LIST:
             if user_input == "y":
                 self._state = self.State.DONE
                 return ""
             else:
-                return goto_input_list()
+                self._ip = ""
+                self._cidrs = ""
+                self._state = self.State.SET_VALIDATE_FORMAT
+                return input_blocks_msg
+
         elif s == self.State.DONE:
             return ""
 
+    # Parses comma-separated CIDR blocks in a string.
+    #
+    # A formatted list of invalid blocks will be returned in the second
+    # tuple slot if any are present.
+    def _parse_blocks(input: str) -> (List[str], str):
+        # Validate each block in list.
+        errors = ""
+        blocks = []
+        for b in input.split(","):
+            b = b.strip()
+            if b == "":
+                continue
+            if CIDRInputStateMachine.valid_cidr_re.fullmatch(b) == None:
+                errors += f"  {b}\n"
+            blocks.append(b)
+        return (blocks, errors)
+
+    # Formats a list of strings according to how terraform wants it.
+    def _format_blocks(blocks: List[str]) -> str:
+        # Terraform expects lists in the `["item1", "item2", ..., "itemN"]` format:
+        # https://developer.hashicorp.com/terraform/language/values/variables#variables-on-the-command-line
+        #
+        # Notably, single quotes are not valid. Strings in lists formatted in f-strings are wrapped in single
+        # quotes so we need to replace them with double quotes.
+        return f"{blocks}".replace("'", '"')
+
+    # Returns the final CIDR allow-list.
     def cidrs(self) -> CIDRList:
         if self._state == self.State.DONE:
             return self._cidrs

--- a/cloud/aws/bin/pgadmin.py
+++ b/cloud/aws/bin/pgadmin.py
@@ -44,7 +44,7 @@ def run(config: ConfigLoader):
 def _get_cidr_list() -> str:
     """Runs the CIDRInputStateMachine until the end state is reached."""
     print(
-        "REQUIRED: configure IPv4 CIDR allow-list for pgadmin. The public IP of the host running the\n"
+        "\nREQUIRED: configure IPv4 CIDR allow-list for pgadmin. The public IP of the host running the\n"
         "web browser used to access pgadmin is required to be covered by a CIDR block in the list.\n\n"
         "The public IP of the host running this tool is optional and allows the tool to wait until\n"
         "pgadmin is available to print out connection information. This wait is cancellable. If the\n"

--- a/cloud/aws/bin/pgadmin_test.py
+++ b/cloud/aws/bin/pgadmin_test.py
@@ -1,5 +1,8 @@
 import unittest
 
+from dataclasses import dataclass
+from typing import List
+
 from cloud.aws.bin.pgadmin import CIDRInputStateMachine
 """
  Tests for the CIDRInputStateMachine.
@@ -14,18 +17,83 @@ def ip(ip):
 
 class TestCIDRInputStateMachine(unittest.TestCase):
 
-    def test_detected_ip_prompts_for_accept(self):
+    def test_first_state_is_detect_ip(self):
+        sm = CIDRInputStateMachine(ip("127.0.0.1"))
+
+        self.assertEqual(sm._state, sm.State.DETECT_IP)
+        self.assertEqual(sm._ip, "")
+        self.assertEqual(sm._cidrs, "")
+
+    def test_first_state_is_detect_ip_even_if_detect_ip_disabled(self):
+        sm = CIDRInputStateMachine(ip(""))
+
+        self.assertEqual(sm._state, sm.State.DETECT_IP)
+        self.assertEqual(sm._ip, "")
+        self.assertEqual(sm._cidrs, "")
+
+    def test_detected_ip_prompts_to_use_ip(self):
         sm = CIDRInputStateMachine(ip("127.0.0.1"))
         sm.next("")
 
-        self.assertEqual(sm._state, sm.State.ACCEPT_LIST)
-        self.assertEqual(sm._cidrs, '["127.0.0.1/32"]')
+        self.assertEqual(sm._state, sm.State.ADD_DETECTED_IP)
+        self.assertEqual(sm._ip, "127.0.0.1")
+        self.assertEqual(sm._cidrs, "")
+
+    def test_accepting_ip_prompts_for_additional_blocks(self):
+        sm = CIDRInputStateMachine(ip("127.0.0.1"))
+        sm.next("")
+
+        sm.next("y")
+
+        self.assertEqual(sm._state, sm.State.APPEND_VALIDATE_FORMAT)
+        self.assertEqual(sm._ip, "127.0.0.1")
+        self.assertEqual(sm._cidrs, "")
+
+    def test_accepting_ip_appends_it_to_list(self):
+        sm = CIDRInputStateMachine(ip("127.0.0.1"))
+        sm.next("")
+
+        sm.next("y")
+        sm.next("128.0.0.1/32")
+        sm.next("y")
+
+        self.assertEqual(sm._state, sm.State.DONE)
+        self.assertEqual(sm._ip, "127.0.0.1")
+        self.assertEqual(sm._cidrs, '["127.0.0.1/32", "128.0.0.1/32"]')
+
+    def test_using_ip_then_not_accepting_list_removes_ip(self):
+        sm = CIDRInputStateMachine(ip("127.0.0.1"))
+        sm.next("")
+
+        sm.next("y")
+        sm.next("128.0.0.1/32")
+        sm.next("n")
+
+        self.assertEqual(sm._state, sm.State.SET_VALIDATE_FORMAT)
+        self.assertEqual(sm._ip, "")
+        self.assertEqual(sm._cidrs, "")
+
+    def test_using_ip_then_not_accepting_list_then_inputting_list_does_not_have_ip(
+            self):
+        sm = CIDRInputStateMachine(ip("127.0.0.1"))
+        sm.next("")
+
+        sm.next("y")
+        sm.next("128.0.0.2/32")
+        sm.next("n")
+        sm.next("128.0.0.2/32")
+        sm.next("y")
+
+        self.assertEqual(sm._state, sm.State.DONE)
+        self.assertEqual(sm._ip, "")
+        self.assertEqual(sm._cidrs, '["128.0.0.2/32"]')
 
     def test_no_detected_ip_prompts_for_input(self):
         sm = CIDRInputStateMachine(ip(""))
         sm.next("")
 
         self.assertEqual(sm._state, sm.State.SET_VALIDATE_FORMAT)
+        self.assertEqual(sm._ip, "")
         self.assertEqual(sm._cidrs, "")
 
     def test_accept_list_completes_machine(self):
@@ -85,6 +153,15 @@ class TestCIDRInputStateMachine(unittest.TestCase):
         self.assertEqual(sm._state, sm.State.SET_VALIDATE_FORMAT)
         self.assertEqual(sm._cidrs, "")
 
+    def test_empty_cidr_list_not_valid(self):
+        sm = CIDRInputStateMachine(ip(""))
+        sm.next("")
+
+        sm.next("")
+
+        self.assertEqual(sm._state, sm.State.SET_VALIDATE_FORMAT)
+        self.assertEqual(sm._cidrs, "")
+
     def test_cidrs_returns_empty_string_until_done(self):
         sm = CIDRInputStateMachine(ip(""))
 
@@ -107,6 +184,110 @@ class TestCIDRInputStateMachine(unittest.TestCase):
         sm.next("y")
         self.assertEqual(sm._state, sm.State.DONE)
         self.assertEqual(sm.cidrs(), '["127.0.0.1/32"]')
+
+    def test_parse_blocks(self):
+
+        @dataclass
+        class TestCase:
+            input: str
+            want: List[str]
+
+        tests = [
+            TestCase(
+                input="",
+                want=[],
+            ),
+            TestCase(
+                input="127.0.0.1/32",
+                want=["127.0.0.1/32"],
+            ),
+            TestCase(
+                input=",127.0.0.1/32",
+                want=["127.0.0.1/32"],
+            ),
+            TestCase(
+                input=",127.0.0.1/32,",
+                want=["127.0.0.1/32"],
+            ),
+            TestCase(
+                input="127.0.0.1/32,127.0.0.2/32",
+                want=["127.0.0.1/32", "127.0.0.2/32"],
+            ),
+            TestCase(
+                input="     127.0.0.1/32              ,127.0.0.2/32,",
+                want=["127.0.0.1/32", "127.0.0.2/32"],
+            ),
+        ]
+        for test in tests:
+            got, got_errors = CIDRInputStateMachine._parse_blocks(test.input)
+            self.assertEqual(
+                got_errors,
+                "",
+                msg=
+                f"CIDRInputStateMachine._parse_blocks({test.input}) returned errors {got_errors}, expected none"
+            )
+            self.assertListEqual(
+                got,
+                test.want,
+                msg=
+                f"CIDRInputStateMachine._parse_blocks({test.input}) returned {got}, expected {test.want}"
+            )
+
+    def test_parse_blocks_errors(self):
+
+        @dataclass
+        class TestCase:
+            input: str
+            want: str
+
+        tests = [
+            TestCase(
+                input="this_is_an_ip",
+                want="  this_is_an_ip\n",
+            ),
+            TestCase(
+                input="256.0.0.1",
+                want="  256.0.0.1\n",
+            ),
+            TestCase(
+                input="127.0.0.1/33",
+                want="  127.0.0.1/33\n",
+            ),
+            TestCase(
+                input="256.0.0.1,127.0.0.1/33",
+                want="  256.0.0.1\n  127.0.0.1/33\n",
+            ),
+        ]
+        for test in tests:
+            _, got = CIDRInputStateMachine._parse_blocks(test.input)
+            self.assertEqual(
+                got,
+                test.want,
+                msg=
+                f"CIDRInputStateMachine._parse_blocks({test.input}) returned errors {got}, expected {test.want}"
+            )
+
+    def test_format_blocks(self):
+
+        @dataclass
+        class TestCase:
+            input: List[str]
+            want: str
+
+        tests = [
+            TestCase(input=["127.0.0.1/32"], want='["127.0.0.1/32"]'),
+            TestCase(
+                input=["127.0.0.1/32", "127.0.0.2/32"],
+                want='["127.0.0.1/32", "127.0.0.2/32"]')
+        ]
+        for test in tests:
+            got = CIDRInputStateMachine._format_blocks(test.input)
+            self.assertEqual(
+                got,
+                test.want,
+                msg=
+                f"CIDRInputStateMachine._format_blocks({test.input}) returned {got}, expected {test.want}"
+            )
 
 
 if __name__ == "__main__":

--- a/cloud/aws/bin/pgadmin_test.py
+++ b/cloud/aws/bin/pgadmin_test.py
@@ -81,12 +81,12 @@ class TestCIDRInputStateMachine(unittest.TestCase):
         sm.next("y")
         sm.next("128.0.0.2/32")
         sm.next("n")
-        sm.next("128.0.0.2/32")
+        sm.next("129.0.0.3/32")
         sm.next("y")
 
         self.assertEqual(sm._state, sm.State.DONE)
         self.assertEqual(sm._ip, "")
-        self.assertEqual(sm._cidrs, '["128.0.0.2/32"]')
+        self.assertEqual(sm._cidrs, '["129.0.0.3/32"]')
 
     def test_no_detected_ip_prompts_for_input(self):
         sm = CIDRInputStateMachine(ip(""))

--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -35,7 +35,7 @@ def main():
             exit()
         os.environ['TF_VAR_image_tag'] = normalize_tag(args.tag)
         sys.stderr.write(
-            f'Running command with tag {os.environ["TF_VAR_image_tag"]}')
+            f'Running command with tag {os.environ["TF_VAR_image_tag"]}\n')
     elif args.command is not None and args.command in ['setup', 'deploy']:
         exit('--tag is required')
 


### PR DESCRIPTION
During development, I accessed the pgadmin web UI from the same host that I was running the deploy tool on.  This is not the common scenario for our partners, however.  The deploy tool is more-often run from a shared VM.

Update the pgadmin command to be aware of this common use case:

- Explain why adding the IP of the host running the tool may still be useful.
- Print link to website to find public IP of host running the web browser. 
- Make the pgadmin service availability polling cancelled with user input.