### PR TITLE
Setup command can successfully run in a blank AWS account

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -39,6 +39,15 @@ class Setup(AwsSetupTemplate):
         print(' - Running the setup script in terraform')
         self._tf_run_for_aws(is_destroy=False)
 
+    def should_retry_terraform_apply_once(self):
+        """
+        The initial terraform apply after the setup step fails due to
+        https://github.com/hashicorp/terraform-provider-aws/issues/19583.
+
+        Re-running terraform apply will succeed, however.
+        """
+        return True
+
     def requires_post_terraform_setup(self):
         return True
 

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -23,6 +23,9 @@ class Setup(SetupTemplate):
     def requires_post_terraform_setup(self):
         return True
 
+    def should_retry_terraform_apply_once(self):
+        return False
+
     def pre_terraform_setup(self):
         print(" - Setting up the keyvault")
         self._setup_keyvault()

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -37,7 +37,12 @@ def run(config: ConfigLoader, params: List[str]):
         # Terraform Init/Plan/Apply
         ###############################################################################
         print("Starting terraform deploy")
-        terraform.perform_apply(config)
+        try:
+            terraform.perform_apply(config)
+        except subprocess.CalledProcessError:
+            if template_setup.should_retry_terraform_apply_once():
+                print("Initial terraform apply failed, retrying once:")
+                terraform.perform_apply(config)
 
         ###############################################################################
         # Post Run Setup Tasks (if needed)


### PR DESCRIPTION
Without this change, setup has to be run twice because the initial terraform apply after setup fails due to known issue https://github.com/hashicorp/terraform-provider-aws/issues/19583. 

This change allows us to run bin/setup in an automated end-to-end test.

Fixes https://github.com/civiform/civiform/issues/3634