### PR TITLE
Add random ID to managed grafana description

### DIFF
--- a/cloud/aws/templates/aws_oidc/monitoring.tf
+++ b/cloud/aws/templates/aws_oidc/monitoring.tf
@@ -2,9 +2,13 @@ resource "aws_prometheus_workspace" "metrics" {
   alias = "${var.app_prefix}-CiviForm_metrics"
 }
 
+resource "random_id" "grafana_workspace_id" {
+  byte_length = 1
+}
+
 resource "aws_grafana_workspace" "CiviForm_metrics" {
   name                     = "${var.app_prefix}-civiform-metrics"
-  description              = "Grafana instance for ${var.app_prefix}-civiform-metrics"
+  description              = "Grafana instance for ${var.app_prefix}-civiform-metrics-${random_id.grafana_workspace_id.dec}"
   data_sources             = ["PROMETHEUS"]
   account_access_type      = "CURRENT_ACCOUNT"
   role_arn                 = aws_iam_role.grafana_assume_role.arn


### PR DESCRIPTION
This is needed to work around known issue https://github.com/hashicorp/terraform-provider-aws/issues/26111.

Users have not encountered this issue before because they have not removed CiviForm resources from their AWS account then re-deployed CiviForm.  Fixing this issue is required to run automated end-to-end tests in an AWS account.

Tested:
1. Ran bin/setup on an empty AWS account.  Setup and initial deployment succeeds.
2. Ran bin/deploy to ensure grafana workspace is not regenerated.  It is not because the random_id resource only changes if it has a `keepers` attribute specified: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id#keepers.