### PR TITLE
Add civiform container healthcheck, wait until service is healthy.

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -13,10 +13,7 @@ def run(config):
 
     if config.is_test():
         print('Test completed')
+        return
 
-    print()
-    print('Deployment finished. You can monitor civiform tasks status here:')
-    print(
-        AwsCli(config).get_url_of_fargate_tasks(
-            f'{config.app_prefix}-{resources.CLUSTER}',
-            f'{config.app_prefix}-{resources.FARGATE_SERVICE}'))
+    aws = AwsCli(config)
+    aws.wait_for_ecs_service_healthy()

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -138,10 +138,10 @@ module "civiform_server_container_def" {
   ]
 
   healthcheck = {
-    command = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/playIndex --output-document - > /dev/null 2>&1"]
-    interval = 10
-    timeout = 11
-    retries = 5
+    command     = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/playIndex --output-document - > /dev/null 2>&1"]
+    interval    = 10
+    timeout     = 11
+    retries     = 5
     startPeriod = 10
   }
 

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -137,6 +137,14 @@ module "civiform_server_container_def" {
     },
   ]
 
+  healthcheck = {
+    command = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/playIndex --output-document - > /dev/null 2>&1"]
+    interval = 10
+    timeout = 11
+    retries = 5
+    startPeriod = 10
+  }
+
   log_configuration = {
     logDriver = "awslogs"
     options = {

--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -1,8 +1,10 @@
 import shlex
 import subprocess
 import json
+import time
 from typing import Dict
 
+from cloud.aws.templates.aws_oidc.bin import resources
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 
 
@@ -11,6 +13,8 @@ class AwsCli:
 
     def __init__(self, config: ConfigLoader):
         self.config: ConfigLoader = config
+        self._ecs_cluster = f"{config.app_prefix}-{resources.CLUSTER}"
+        self._ecs_service = f"{config.app_prefix}-{resources.FARGATE_SERVICE}"
 
     def get_secret_value(self, secret_name: str) -> str:
         res = self._call_cli(
@@ -37,10 +41,86 @@ class AwsCli:
             f"rds modify-db-instance --db-instance-identifier={db_name} --master-user-password={password} "
         )
 
-    def restart_ecs_service(self, cluster: str, service_name: str):
+    def restart_ecs_service(self):
+        """
+        Restarts the CiviForm ECS service.
+        """
         self._call_cli(
-            f"ecs update-service --force-new-deployment --service={service_name} --cluster={cluster}"
+            f"ecs update-service --force-new-deployment --cluster={self._ecs_cluster} --service={self._ecs_service}"
         )
+
+    def wait_for_ecs_service_healthy(self):
+        """
+        Polls the CiviForm ECS service, waiting for the PRIMARY deployment to
+        have rolloutStatus of COMPLETED.
+
+        Gives up after 20 tries, sleeps 30 seconds between each try.
+        """
+        print(
+            "\nWaiting for CiviForm ECS service to become healthy.\n"
+            f"Service URL: {self._get_url_of_ecs_service()}"
+        )
+
+        tries = 20
+        while True:
+            state = self. _ecs_service_state()
+            if state == "COMPLETED":
+                print("Service is healthy.")
+                return
+
+            tries -= 1
+            if tries == 0:
+                print(
+                    "\nERROR: service did not become healthy in expected amount of time. This usually means the new tasks are crash-looping.\n"
+                    "To see the task logs, follow https://docs.civiform.us/it-manual/sre-playbook/terraform-deploy-system/terraform-aws-deployment#inspecting-logs\n"
+                    "For debugging help, contact the CiviForm oncall: https://docs.civiform.us/governance-and-management/project-management/on-call-guide#on-call-responsibilities"
+                )
+                return
+
+            print(
+                f"  Service in state {state}. Retrying ({tries} left) in 30 seconds..."
+            )
+            time.sleep(30)
+
+    def _ecs_service_state(self) -> str:
+        """
+        Returns the rolloutState of the PRIMARY ECS service deployment. If
+        the CiviForm service is not found or there is no PRIMARY deployment
+        found, "NONE" is returned.
+
+        An ECS service has many deployments. Each deployment has a status of
+        PRIMARY, ACTIVE, or INACTIVE. There can only be one deployment with the
+        PRIMARY status. A deployment with this status is the most recent
+        deployment.
+
+        Each deployment has a rolloutState of COMPLETED, FAILED, or IN_PROGRESS.
+        The deployment becomes COMPLETED when all its containers pass their
+        healthchecks.
+
+        For CiviForm, the service usually only has deployment. When we upgrade
+        the CiviForm server version, the deployment for the old version goes to
+        ACTIVE and a new PRIMARY deployment is created for the new version.
+        Once the new PRIMARY deployment has a rolloutState of COMPLETED, the
+        ACTIVE deployment stops its tasks and goes to the INACTIVE state.
+
+        https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Deployment.html.
+        """
+        res = self._call_cli(
+            f"ecs describe-services --cluster={self._ecs_cluster} --services={self._ecs_service}"
+        )
+
+        services = res["services"]
+        if services == None or len(services) != 1:
+            return "NONE"
+
+        for deployment in services[0]["deployments"]:
+            if deployment["status"] == "PRIMARY":
+                return deployment["rolloutState"]
+
+        return "NONE"
+
+    def _get_url_of_ecs_service(self) -> str:
+        return f"https://{self.config.aws_region}.console.aws.amazon.com/ecs/v2/clusters/{self._ecs_cluster}/services/{self._ecs_service}/deployments"
 
     def get_load_balancer_dns(self, name: str) -> str:
         res = self._call_cli(f"elbv2 describe-load-balancers --names={name}")
@@ -52,9 +132,6 @@ class AwsCli:
 
     def get_url_of_s3_bucket(self, bucket_name: str) -> str:
         return f"https://{self.config.aws_region}.console.aws.amazon.com/s3/buckets/{bucket_name}"
-
-    def get_url_of_fargate_tasks(self, cluster: str, service_name: str) -> str:
-        return f"https://{self.config.aws_region}.console.aws.amazon.com/ecs/v2/clusters/{cluster}/services/{service_name}/configuration"
 
     def _call_cli(self, command: str) -> Dict:
         command = f"aws --output=json --region={self.config.aws_region} " + command

--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -58,12 +58,11 @@ class AwsCli:
         """
         print(
             "\nWaiting for CiviForm ECS service to become healthy.\n"
-            f"Service URL: {self._get_url_of_ecs_service()}"
-        )
+            f"Service URL: {self._get_url_of_ecs_service()}")
 
         tries = 20
         while True:
-            state = self. _ecs_service_state()
+            state = self._ecs_service_state()
             if state == "COMPLETED":
                 print("Service is healthy.")
                 return

--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -96,11 +96,12 @@ class AwsCli:
         The deployment becomes COMPLETED when all its containers pass their
         healthchecks.
 
-        For CiviForm, the service usually only has deployment. When we upgrade
-        the CiviForm server version, the deployment for the old version goes to
-        ACTIVE and a new PRIMARY deployment is created for the new version.
-        Once the new PRIMARY deployment has a rolloutState of COMPLETED, the
-        ACTIVE deployment stops its tasks and goes to the INACTIVE state.
+        For CiviForm, the service usually only has one deployment. When we
+        upgrade the CiviForm server version, the deployment for the old version
+        goes to ACTIVE and a new PRIMARY deployment is created for the new
+        version. Once the new PRIMARY deployment has a rolloutState of
+        COMPLETED, the ACTIVE deployment stops its tasks and goes to the
+        INACTIVE state.
 
         https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Deployment.html.
         """

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -60,6 +60,7 @@ class Setup(AwsSetupTemplate):
             self._maybe_set_secret_value(
                 f'{self.config.app_prefix}-{name}', doc)
         self._maybe_change_default_db_password()
+        self._aws_cli.wait_for_ecs_service_healthy()
         self._print_final_message()
 
     def _maybe_set_secret_value(self, secret_name: str, documentation: str):
@@ -110,9 +111,7 @@ class Setup(AwsSetupTemplate):
                 f'{app_prefix}-{resources.DATABASE}', new_password)
             print('Database password has been changed.')
             self._aws_cli.set_secret_value(secret_name, new_password)
-            self._aws_cli.restart_ecs_service(
-                f'{app_prefix}-{resources.CLUSTER}',
-                f'{app_prefix}-{resources.FARGATE_SERVICE}')
+            self._aws_cli.restart_ecs_service()
             print(f'ECS service has been restarted to pickup the new password.')
         else:
             print('Password has already been changed. Not touching it.')
@@ -122,15 +121,6 @@ class Setup(AwsSetupTemplate):
 
     def _print_final_message(self):
         app = self.config.app_prefix
-
-        # Print link to ECS tasks.
-        print()
-        fargate_service = f'{app}-{resources.FARGATE_SERVICE}'
-        cluster = f'{app}-{resources.CLUSTER}'
-        tasks_url = self._aws_cli.get_url_of_fargate_tasks(
-            cluster, fargate_service)
-        print('Setup finished. You can monitor civiform tasks status here:')
-        print(tasks_url)
 
         # Print info about load balancer url.
         print()


### PR DESCRIPTION
By adding container healthchecks to civiform task definition, we can tell if the service is in the desired state by inspecting the service deployments.

Add code in bin/{setup,deploy} to wait for the service to reach desired state. Containers have to pass their healthchecks for the deployment to complete so this solves the "deploy tool completes without any error but the civiform container is crashlooping" issue.

Fixes https://github.com/civiform/civiform/issues/2845.
Fixes https://github.com/civiform/civiform/issues/3801.