### PR TITLE
Updating configure-aws-credentials action to use node16

### DIFF
--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-1
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - id: get-aws-creds
         name: Authenticate to AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           # Role in cloud-deploy-infra-tests-0 account.
           role-to-assume: arn:aws:iam::178882378957:role/e2e-test-runner


### PR DESCRIPTION
Node16 is handled under a different tag. See https://github.com/aws-actions/configure-aws-credentials/issues/489