### PR TITLE
Support showing civiform version on landing page

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -84,13 +84,15 @@ module "civiform_server_container_def" {
     STORAGE_SERVICE_NAME = "s3"
     AWS_S3_BUCKET_NAME   = aws_s3_bucket.civiform_files_s3.id
 
-    CIVIFORM_TIME_ZONE_ID              = var.civiform_time_zone_id
-    WHITELABEL_CIVIC_ENTITY_SHORT_NAME = var.civic_entity_short_name
-    WHITELABEL_CIVIC_ENTITY_FULL_NAME  = var.civic_entity_full_name
-    WHITELABEL_SMALL_LOGO_URL          = var.civic_entity_small_logo_url
-    WHITELABEL_LOGO_WITH_NAME_URL      = var.civic_entity_logo_with_name_url
-    FAVICON_URL                        = var.favicon_url
-    SUPPORT_EMAIL_ADDRESS              = var.civic_entity_support_email_address
+    CIVIFORM_IMAGE_TAG                      = var.image_tag
+    SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE = var.show_civiform_image_tag_on_landing_page
+    CIVIFORM_TIME_ZONE_ID                   = var.civiform_time_zone_id
+    WHITELABEL_CIVIC_ENTITY_SHORT_NAME      = var.civic_entity_short_name
+    WHITELABEL_CIVIC_ENTITY_FULL_NAME       = var.civic_entity_full_name
+    WHITELABEL_SMALL_LOGO_URL               = var.civic_entity_small_logo_url
+    WHITELABEL_LOGO_WITH_NAME_URL           = var.civic_entity_logo_with_name_url
+    FAVICON_URL                             = var.favicon_url
+    SUPPORT_EMAIL_ADDRESS                   = var.civic_entity_support_email_address
 
     AWS_SES_SENDER = var.sender_email_address
     AWS_REGION     = var.aws_region

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -341,3 +341,8 @@ variable "pgadmin_cidr_allowlist" {
   description = "List of IPv4 cidr blocks that are allowed access to pgadmin"
   default     = []
 }
+variable "show_civiform_image_tag_on_landing_page" {
+  type        = bool
+  description = "Whether to show civiform version on landing page or not."
+  default     = false
+}

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -170,5 +170,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }
 }


### PR DESCRIPTION
This is a companion PR to https://github.com/civiform/civiform/pull/4171.

Tested:
1. Built a prod civiform image from https://github.com/civiform/civiform/pull/4171, pushed to docker.io/avritt/civiform:v0.0.1.
2. Added SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE=true to my civiform_config.sh file.
3. Updated the default for `civiform_image_repo` to `avritt/civiform` in cloud-deploy-infra/cloud/aws/templates/aws_oicd/variables.tf.
4. Deployed civiform to my test account.  Result: 
![image](https://user-images.githubusercontent.com/17995083/217392202-ed61295b-6411-4b63-a781-62e6ceed599f.png)
