### PR TITLE
Support setting STAGING_ADD_NOINDEX_META_TAG, STAGING_DISABLE_DEMO_MODE_LOGINS, and STAGING_DISABLE_APPLICATION_GUEST_LOGIN in AWS

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -100,6 +100,9 @@ module "civiform_server_container_def" {
     STAGING_ADMIN_LIST                        = var.staging_program_admin_notification_mailing_list
     STAGING_TI_LIST                           = var.staging_ti_notification_mailing_list
     STAGING_APPLICANT_LIST                    = var.staging_applicant_notification_mailing_list
+    STAGING_ADD_NOINDEX_META_TAG              = var.staging_add_noindex_meta_tag
+    STAGING_DISABLE_DEMO_MODE_LOGINS          = var.staging_disable_demo_mode_logins
+    STAGING_DISABLE_APPLICANT_GUEST_LOGIN     = var.staging_disable_applicant_guest_login
     APPLICANT_OIDC_PROVIDER_NAME              = var.applicant_oidc_provider_name
     CIVIFORM_APPLICANT_IDP                    = var.civiform_applicant_idp
     APPLICANT_OIDC_PROVIDER_LOGOUT            = var.applicant_oidc_provider_logout

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -346,3 +346,18 @@ variable "show_civiform_image_tag_on_landing_page" {
   description = "Whether to show civiform version on landing page or not."
   default     = false
 }
+variable "staging_add_noindex_meta_tag" {
+  type        = bool
+  description = "Whether to show civiform version on landing page or not."
+  default     = false
+}
+variable "staging_disable_demo_mode_logins" {
+  type        = bool
+  description = "Whether to show civiform version on landing page or not."
+  default     = false
+}
+variable "staging_disable_applicant_guest_login" {
+  type        = bool
+  description = "Whether to show civiform version on landing page or not."
+  default     = false
+}

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -348,16 +348,16 @@ variable "show_civiform_image_tag_on_landing_page" {
 }
 variable "staging_add_noindex_meta_tag" {
   type        = bool
-  description = "Whether to show civiform version on landing page or not."
+  description = "Whether to add a robots=noindex meta tag, which causes search engines to not list the website."
   default     = false
 }
 variable "staging_disable_demo_mode_logins" {
   type        = bool
-  description = "Whether to show civiform version on landing page or not."
+  description = "Whether to disable the demo mode login buttons."
   default     = false
 }
 variable "staging_disable_applicant_guest_login" {
   type        = bool
-  description = "Whether to show civiform version on landing page or not."
+  description = "Whether to disable the guest login button."
   default     = false
 }

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -176,5 +176,23 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "STAGING_ADD_NOINDEX_META_TAG": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "STAGING_DISABLE_DEMO_MODE_LOGINS": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "STAGING_DISABLE_APPLICANT_GUEST_LOGIN": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/civiform/civiform/pull/4214.

Tested: deployed in my dev project with all new variables set to true: 
![aws-deployed](https://user-images.githubusercontent.com/17995083/219090066-6b0f7d3b-b90e-41fc-9187-32458d97860f.png)
