### PR TITLE
Configure retries for e2e test post nuke step

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -2,7 +2,7 @@ name: e2e-test
 on:
   # Runs every day at 3:12 UTC.
   schedule:
-    - cron: '12 3 * * *'
+    - cron: "12 3 * * *"
   # Allow manually triggered runs.
   workflow_dispatch:
 
@@ -61,4 +61,8 @@ jobs:
         # default:
         # https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions.
         if: (success() || failure()) && steps.get-nuke.outcome == 'success' && steps.get-aws-creds.outcome == 'success'
-        run: /aws-nuke --config $GITHUB_WORKSPACE/cloud-deploy-infra/e2e-test/nuke.yaml --no-dry-run --force --force-sleep=3
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: /aws-nuke --config $GITHUB_WORKSPACE/cloud-deploy-infra/e2e-test/nuke.yaml --no-dry-run --force --force-sleep=3


### PR DESCRIPTION
Most e2e failures (see https://github.com/civiform/civiform/issues/4034) have been due to a known issue with aws-nuke: https://github.com/rebuy-de/aws-nuke/issues/500.  There is a fix on its main branch but a new release has not been cut since 2022-12.  Re-running aws-nuke always resolves the issue.  This change mitigates the issue while we wait for the aws-nuke fix to be released.

Utilizes https://github.com/nick-fields/retry (no builtin retry config is provided by GitHub actions).