### PR TITLE
Set CIVIFORM_VERSION instead of CIVIFORM_IMAGE_TAG

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -84,7 +84,7 @@ module "civiform_server_container_def" {
     STORAGE_SERVICE_NAME = "s3"
     AWS_S3_BUCKET_NAME   = aws_s3_bucket.civiform_files_s3.id
 
-    CIVIFORM_IMAGE_TAG                      = var.image_tag
+    CIVIFORM_VERSION                        = var.image_tag
     SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE = var.show_civiform_image_tag_on_landing_page
     CIVIFORM_TIME_ZONE_ID                   = var.civiform_time_zone_id
     WHITELABEL_CIVIC_ENTITY_SHORT_NAME      = var.civic_entity_short_name


### PR DESCRIPTION
CIVIFORM_VERSION was added in https://github.com/civiform/civiform/pull/4405.  CIVIFORM_IMAGE_TAG is set in the prod.Dockerfile: https://github.com/civiform/civiform/blob/main/prod.Dockerfile#L46.

This change makes it so if CIVIFORM_VERSION in the civiform_config.sh file is set to "latest", the image tag (SNAPSHOT-3af89974-1678907834 for example) is show on the login page when SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is enabled instead of "latest".  If CIVIFORM_VERSION is a release version like v1.18.0, only the release version is shown.

Fixes https://github.com/civiform/civiform/issues/4270.

Tested: Set CIVIFORM_VERSION to "latest" and deployed in my dev account, snapshot version is shown: 
![image](https://user-images.githubusercontent.com/17995083/225743986-8dc24794-e984-40d4-b9c3-62c14b9192b7.png)
