### PR TITLE
Add env vars for common intake

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -125,6 +125,9 @@ module "civiform_server_container_def" {
     ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS      = var.allow_civiform_admin_access_programs
     PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED    = var.program_eligibility_conditions_enabled
 
+    COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT    = var.common_intake_more_resources_link_text
+    COMMON_INTAKE_MORE_RESOURCES_LINK_HREF    = var.common_intake_more_resources_link_href
+
 
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -125,8 +125,8 @@ module "civiform_server_container_def" {
     ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS      = var.allow_civiform_admin_access_programs
     PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED    = var.program_eligibility_conditions_enabled
 
-    COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT    = var.common_intake_more_resources_link_text
-    COMMON_INTAKE_MORE_RESOURCES_LINK_HREF    = var.common_intake_more_resources_link_href
+    COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT = var.common_intake_more_resources_link_text
+    COMMON_INTAKE_MORE_RESOURCES_LINK_HREF = var.common_intake_more_resources_link_href
 
 
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -372,3 +372,13 @@ variable "program_eligibility_conditions_enabled" {
   description = "Whether to enable program eligibility conditions"
   default     = false
 }
+variable "common_intake_more_resources_link_text" {
+  type        = string
+  description = "The text for a link on the Common Intake confirmation page that links to more resources. Shown when the applicant is not eligible for any programs in CiviForm."
+  default     = "Access Arkansas"
+}
+variable "common_intake_more_resources_link_href" {
+  type        = string
+  description = "The HREF for a link on the Common Intake confirmation page that links to more resources. Shown when the applicant is not eligible for any programs in CiviForm."
+  default     = "https://access.arkansas.gov/Learn/Home"
+}

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -206,5 +206,17 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT": {
+    "required": false,
+    "secret": false,
+    "tfvar": false,
+    "type": "string"
+  },
+  "COMMON_INTAKE_MORE_RESOURCES_LINK_HREF": {
+    "required": false,
+    "secret": false,
+    "tfvar": false,
+    "type": "string"
   }
 }


### PR DESCRIPTION
Part of https://github.com/civiform/civiform/issues/4380

Adds two env vars used by the common intake upsell page. See the linked issue for additional context.