### PR TITLE
Add ability to restore DB to snapshot

### DIFF
--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -29,6 +29,9 @@ resource "aws_db_instance" "civiform" {
     Name = "${var.app_prefix} Civiform Database"
     Type = "Civiform Database"
   }
+
+  # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
+  snapshot_identifier             = var.postgres_restore_snapshot_identifier
   deletion_protection             = local.deletion_protection
   instance_class                  = var.postgres_instance_class
   allocated_storage               = var.postgres_storage_gb

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -184,5 +184,11 @@
     "secret": false,
     "tfvar": true,
     "type": "integer"
+  },
+  "POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -118,6 +118,12 @@ variable "postgres_backup_retention_days" {
   default     = 7
 }
 
+variable "postgres_restore_snapshot_identifier" {
+  type        = string
+  description = "If not null, destroys the current database, replacing it with a new one restored from the provided snapshot"
+  default     = null
+}
+
 variable "staging_program_admin_notification_mailing_list" {
   type        = string
   description = "Admin notification mailing list for staging"


### PR DESCRIPTION
Adds `POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER` config var which can be used to destroy the replace the database with a new one restored from the specified snapshot.

The RDS instance has deletion protection on my default, requiring the deployer to access the AWS console and disable it before this can be used.