### PR TITLE
Change civiform_files_ownership controls to BucketOwnerPreferred

### DIFF
--- a/cloud/aws/templates/aws_oidc/filestorage.tf
+++ b/cloud/aws/templates/aws_oidc/filestorage.tf
@@ -70,7 +70,7 @@ resource "aws_s3_bucket_ownership_controls" "civiform_files_ownership" {
   bucket = aws_s3_bucket.civiform_files_s3.id
 
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = "BucketOwnerPreferred"
   }
   depends_on = [aws_s3_bucket_acl.log_bucket_acl]
 }


### PR DESCRIPTION
Attempts to fix https://github.com/civiform/civiform/issues/4697

Based on https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-s3-object-ownership-simplify-access-management-data-s3/ and https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html