### PR TITLE
Set ownership controls on access log bucket

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -350,6 +350,7 @@ module "ecs_fargate_service" {
   ecs_cluster_arn         = module.ecs_cluster.aws_ecs_cluster_cluster_arn
   private_subnets         = module.vpc.private_subnets
   public_subnets          = module.vpc.public_subnets
+  enable_s3_logs          = false
 
   lb_http_ports = {
     default_http = {

--- a/cloud/aws/templates/aws_oidc/filestorage.tf
+++ b/cloud/aws/templates/aws_oidc/filestorage.tf
@@ -70,9 +70,8 @@ resource "aws_s3_bucket_ownership_controls" "civiform_files_ownership" {
   bucket = aws_s3_bucket.civiform_files_s3.id
 
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "BucketOwnerEnforced"
   }
-  depends_on = [aws_s3_bucket_acl.log_bucket_acl]
 }
 
 resource "aws_s3_bucket_logging" "civiform_files_logging" {
@@ -93,8 +92,17 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket     = aws_s3_bucket.log_bucket.id
+  depends_on = [aws_s3_bucket_ownership_controls.file_access_logs_bucket_ownership]
+  acl        = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_ownership_controls" "file_access_logs_bucket_ownership" {
   bucket = aws_s3_bucket.log_bucket.id
-  acl    = "log-delivery-write"
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_versioning" "logging_versioning" {


### PR DESCRIPTION
Followed instructions in https://github.com/hashicorp/terraform-provider-aws/issues/28353 to fix https://github.com/civiform/civiform/issues/4697

This PR also disables storage of load balancer logs on S3. The module we use for creating the fargate service has been setting up an S3 bucket for load balancer logs behind the scenes. We've never had need to view those logs, and don't have cloudwatch set up so that we could look at them without downloading and un-gzipping them directly from S3, which we've never done.

If we merge this PR with LB logs disabled, existing deployments will need to empty their LB log bucket before they'll be able to deploy again, otherwise terraform will fail with an error stating that it can't delete a non-empty bucket.

Alternatively, we could wait for this PR to merge and then update the module version [here](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/aws/templates/aws_oidc/app.tf#L341) once the change has propagated through the intermediate dependencies.

Ran bin/setup and verified the bug ACL error is no longer occurring.