### PR TITLE
Revert "Update Terraform cn-terraform/ecs-fargate-service/aws to v2.0.40"

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -340,7 +340,7 @@ resource "aws_ecs_task_definition" "td" {
 
 module "ecs_fargate_service" {
   source                  = "cn-terraform/ecs-fargate-service/aws"
-  version                 = "2.0.40"
+  version                 = "2.0.39"
   name_prefix             = "${var.app_prefix}-civiform"
   desired_count           = var.fargate_desired_task_count
   default_certificate_arn = var.ssl_certificate_arn


### PR DESCRIPTION
Reverts civiform/cloud-deploy-infra#157

This caused the following errors
```
╷
│ Error: "name" cannot be longer than 32 characters
│ 
│   with module.ecs_fargate_service.module.ecs-alb[0].aws_lb_target_group.lb_https_tgs["default_http"],
│   on .terraform/modules/ecs_fargate_service.ecs-alb/main.tf line 166, in resource "aws_lb_target_group" "lb_https_tgs":
│  166:   name                          = "${var.name_prefix}-${each.key}-https-${each.value.target_group_port}"
│ 
╵
╷
│ Error: only alphanumeric characters and hyphens allowed in "name"
│ 
│   with module.ecs_fargate_service.module.ecs-alb[0].aws_lb_target_group.lb_https_tgs["default_http"],
│   on .terraform/modules/ecs_fargate_service.ecs-alb/main.tf line 166, in resource "aws_lb_target_group" "lb_https_tgs":
│  166:   name                          = "${var.name_prefix}-${each.key}-https-${each.value.target_group_port}"
│ 
╵
```