### PR TITLE
Add ESRI service to AWS staging

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -132,8 +132,8 @@ module "civiform_server_container_def" {
     COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT = var.common_intake_more_resources_link_text
     COMMON_INTAKE_MORE_RESOURCES_LINK_HREF = var.common_intake_more_resources_link_href
 
-    ESRI_ADDRESS_CORRECTION_ENABLED                 = var.esri_address_correction_enabled
-    ESRI_FIND_ADDRESS_CANDIDATES_URL                = var.esri_find_address_candidate_url
+    ESRI_ADDRESS_CORRECTION_ENABLED  = var.esri_address_correction_enabled
+    ESRI_FIND_ADDRESS_CANDIDATES_URL = var.esri_find_address_candidate_url
 
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -132,7 +132,14 @@ module "civiform_server_container_def" {
     COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT = var.common_intake_more_resources_link_text
     COMMON_INTAKE_MORE_RESOURCES_LINK_HREF = var.common_intake_more_resources_link_href
 
-
+    ESRI_ADDRESS_CORRECTION_ENABLED = var.esri_address_correction_enabled
+    ESRI_FIND_ADDRESS_CANDIDATES_URL = var.esri_find_address_candidate_url
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED = var.esri_address_service_area_validation_enabled
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS = var.esri_address_service_area_validation_urls
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS = var.esri_address_service_area_validation_labels
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS = var.esri_address_service_area_validation_ids
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES = var.esri_address_service_area_validation_attributes
+    
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled
     CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET          = var.civiform_api_keys_ban_global_subnet

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -132,15 +132,15 @@ module "civiform_server_container_def" {
     COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT = var.common_intake_more_resources_link_text
     COMMON_INTAKE_MORE_RESOURCES_LINK_HREF = var.common_intake_more_resources_link_href
 
-    ESRI_ADDRESS_CORRECTION_ENABLED = var.esri_address_correction_enabled
-    ESRI_FIND_ADDRESS_CANDIDATES_URL = var.esri_find_address_candidate_url
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED = var.esri_address_service_area_validation_enabled
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS = var.esri_address_service_area_validation_urls
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS = var.esri_address_service_area_validation_labels
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS = var.esri_address_service_area_validation_ids
+    ESRI_ADDRESS_CORRECTION_ENABLED                 = var.esri_address_correction_enabled
+    ESRI_FIND_ADDRESS_CANDIDATES_URL                = var.esri_find_address_candidate_url
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED    = var.esri_address_service_area_validation_enabled
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS       = var.esri_address_service_area_validation_urls
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS     = var.esri_address_service_area_validation_labels
+    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS        = var.esri_address_service_area_validation_ids
     ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES = var.esri_address_service_area_validation_attributes
-    ESRI_EXTERNAL_CALL_TRIES = var.esri_external_call_tries
-    
+    ESRI_EXTERNAL_CALL_TRIES                        = var.esri_external_call_tries
+
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled
     CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET          = var.civiform_api_keys_ban_global_subnet

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -139,6 +139,7 @@ module "civiform_server_container_def" {
     ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS = var.esri_address_service_area_validation_labels
     ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS = var.esri_address_service_area_validation_ids
     ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES = var.esri_address_service_area_validation_attributes
+    ESRI_EXTERNAL_CALL_TRIES = var.esri_external_call_tries
     
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -134,12 +134,6 @@ module "civiform_server_container_def" {
 
     ESRI_ADDRESS_CORRECTION_ENABLED                 = var.esri_address_correction_enabled
     ESRI_FIND_ADDRESS_CANDIDATES_URL                = var.esri_find_address_candidate_url
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED    = var.esri_address_service_area_validation_enabled
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS       = var.esri_address_service_area_validation_urls
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS     = var.esri_address_service_area_validation_labels
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS        = var.esri_address_service_area_validation_ids
-    ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES = var.esri_address_service_area_validation_attributes
-    ESRI_EXTERNAL_CALL_TRIES                        = var.esri_external_call_tries
 
     CIVIFORM_ADMIN_REPORTING_UI_ENABLED          = var.feature_flag_reporting_enabled
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -422,39 +422,3 @@ variable "esri_find_address_candidate_url" {
   description = "The URL CiviForm will use to call Esri’s findAddressCandidates service."
   default     = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
 }
-
-variable "esri_address_service_area_validation_enabled" {
-  type        = bool
-  description = "Enables the feature that allows for service area validation of a corrected address. ESRI_ADDRESS_CORRECTION_ENABLED needs to be enabled."
-  default     = false
-}
-
-variable "esri_address_service_area_validation_urls" {
-  type        = list(string)
-  description = "The URL CiviForm will use to call Esri’s map query service for service area validation."
-  default     = ["https://gisdata.seattle.gov/server/rest/services/COS/Seattle_City_Limits/MapServer/1/query"]
-}
-
-variable "esri_address_service_area_validation_labels" {
-  type        = list(string)
-  description = "Human readable labels used to present the service area validation options in CiviForm’s admin UI."
-  default     = ["Seattle"]
-}
-
-variable "esri_address_service_area_validation_ids" {
-  type        = list(string)
-  description = "The value CiviForm uses to validate if an address is in a service area."
-  default     = ["Seattle"]
-}
-
-variable "esri_address_service_area_validation_attributes" {
-  type        = list(string)
-  description = "The attribute CiviForm checks from the service area validation response to get the service area validation ID."
-  default     = ["CITYNAME"]
-}
-
-variable "esri_external_call_tries" {
-  type        = number
-  description = "The number of tries CiviForm will attempt requests to external Esri services."
-  default     = 3
-}

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -410,3 +410,45 @@ variable "phone_question_type_enabled" {
   description = "Whether to enable the phone question type."
   default     = false
 }
+
+variable "esri_address_correction_enabled" {
+  type        = bool
+  description = "Whether to enable esri address correction."
+  default     = false
+}
+
+variable "esri_find_address_candidate_url" {
+  type        = string
+  description = "Url to use to fetch address suggestions."
+  default     = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+}
+
+variable "esri_address_service_area_validation_enabled" {
+  type        = bool
+  description = "Whether to enable esri service area validation."
+  default     = false
+}
+
+variable "esri_address_service_area_validation_urls" {
+  type        = list(string)
+  description = "Url to use to check if an address is in a given service area."
+  default     = []
+}
+
+variable "esri_address_service_area_validation_labels" {
+  type        = list(string)
+  description = ""
+  default     = ["Seattle"]
+}
+
+variable "esri_address_service_area_validation_ids" {
+  type        = list(string)
+  description = ""
+  default     = ["Seattle"]
+}
+
+variable "esri_address_service_area_validation_attributes" {
+  type        = list(string)
+  description = ""
+  default     = ["CITYNAME"]
+}

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -413,42 +413,48 @@ variable "phone_question_type_enabled" {
 
 variable "esri_address_correction_enabled" {
   type        = bool
-  description = "Whether to enable esri address correction."
+  description = "Enables the feature that allows address correction for address questions."
   default     = false
 }
 
 variable "esri_find_address_candidate_url" {
   type        = string
-  description = "Url to use to fetch address suggestions."
+  description = "The URL CiviForm will use to call Esri’s findAddressCandidates service."
   default     = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
 }
 
 variable "esri_address_service_area_validation_enabled" {
   type        = bool
-  description = "Whether to enable esri service area validation."
+  description = "Enables the feature that allows for service area validation of a corrected address. ESRI_ADDRESS_CORRECTION_ENABLED needs to be enabled."
   default     = false
 }
 
 variable "esri_address_service_area_validation_urls" {
   type        = list(string)
-  description = "Url to use to check if an address is in a given service area."
-  default     = []
+  description = "The URL CiviForm will use to call Esri’s map query service for service area validation."
+  default     = ["https://gisdata.seattle.gov/server/rest/services/COS/Seattle_City_Limits/MapServer/1/query"]
 }
 
 variable "esri_address_service_area_validation_labels" {
   type        = list(string)
-  description = ""
+  description = "Human readable labels used to present the service area validation options in CiviForm’s admin UI."
   default     = ["Seattle"]
 }
 
 variable "esri_address_service_area_validation_ids" {
   type        = list(string)
-  description = ""
+  description = "The value CiviForm uses to validate if an address is in a service area."
   default     = ["Seattle"]
 }
 
 variable "esri_address_service_area_validation_attributes" {
   type        = list(string)
-  description = ""
+  description = "The attribute CiviForm checks from the service area validation response to get the service area validation ID."
   default     = ["CITYNAME"]
+}
+
+variable "esri_external_call_tries" {
+  type        = number
+  description = "The number of tries CiviForm will attempt requests to external Esri services."
+  default     = 3
 }

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -75,8 +75,7 @@ class ValidateVariableDefinitions:
             "integer": self.validate_integer_definition_type,
             "string": self.validate_string_definition_type,
             "enum": self.validate_enum_definition_type,
-            "bool": self.validate_bool_definition_type,
-            "list(string)": self.validate_list_definition_type
+            "bool": self.validate_bool_definition_type
         }
 
         validator = type_specific_validators.get(
@@ -130,7 +129,4 @@ class ValidateVariableDefinitions:
     def validate_enum_definition_type(self, variable_definition):
         if not isinstance(variable_definition.get("values", None), list):
             return ["Missing 'values' field for enum."]
-        return []
-
-    def validate_list_definition_type(self, variable_definition):
         return []

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -76,6 +76,7 @@ class ValidateVariableDefinitions:
             "string": self.validate_string_definition_type,
             "enum": self.validate_enum_definition_type,
             "bool": self.validate_bool_definition_type,
+            "list(string)": self.validate_list_definition_type
         }
 
         validator = type_specific_validators.get(
@@ -129,4 +130,6 @@ class ValidateVariableDefinitions:
     def validate_enum_definition_type(self, variable_definition):
         if not isinstance(variable_definition.get("values", None), list):
             return ["Missing 'values' field for enum."]
+        return []
+    def validate_list_definition_type(self, variable_definition):
         return []

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -75,7 +75,7 @@ class ValidateVariableDefinitions:
             "integer": self.validate_integer_definition_type,
             "string": self.validate_string_definition_type,
             "enum": self.validate_enum_definition_type,
-            "bool": self.validate_bool_definition_type
+            "bool": self.validate_bool_definition_type,
         }
 
         validator = type_specific_validators.get(

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -131,6 +131,6 @@ class ValidateVariableDefinitions:
         if not isinstance(variable_definition.get("values", None), list):
             return ["Missing 'values' field for enum."]
         return []
-        
+
     def validate_list_definition_type(self, variable_definition):
         return []

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -131,5 +131,6 @@ class ValidateVariableDefinitions:
         if not isinstance(variable_definition.get("values", None), list):
             return ["Missing 'values' field for enum."]
         return []
+        
     def validate_list_definition_type(self, variable_definition):
         return []

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -254,41 +254,5 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
-  },
-  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "bool"
-  },
-  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "list(string)"
-  },
-  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "list(string)"
-  },
-  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "list(string)"
-  },
-  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "list(string)"
-  },
-  "ESRI_EXTERNAL_CALL_TRIES": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "integer"
   }
 }

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -289,6 +289,6 @@
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   }
 }

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -242,5 +242,53 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
-  }
+  },
+  "ESRI_ADDRESS_CORRECTION_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "ESRI_FIND_ADDRESS_CANDIDATES_URL": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "list(string)"
+  },
+  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "list(string)"
+  },
+  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "list(string)"
+  },
+  "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "list(string)"
+  },
+  "ESRI_EXTERNAL_CALL_TRIES": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
 }

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -290,5 +290,5 @@
     "secret": false,
     "tfvar": true,
     "type": "number"
-  },
+  }
 }


### PR DESCRIPTION
This PR pipes through the variables we need to enable Esri address correction in staging for AWS. Service area validation vars are not included here because they need to be sent through as arrays/lists which we don't have a pattern for yet (Issue to track that work is here: https://github.com/civiform/civiform/issues/4790). Eventually, we will need to include [all Esri vars](https://github.com/civiform/civiform/blob/fd0aaa002e2ee01d378ca90f236c316641ed0101/server/conf/application.conf#L722) in the deploy system.

Issue: https://github.com/civiform/civiform/issues/4621
Corresponding PR to add these to our AWS staging config file: https://github.com/civiform/civiform-staging-deploy/pull/47