### PR TITLE
Add otel-config file to infra metrics directory

### DIFF
--- a/cloud/aws/metrics/metrics_scraper.Dockerfile
+++ b/cloud/aws/metrics/metrics_scraper.Dockerfile
@@ -1,3 +1,3 @@
 FROM public.ecr.aws/aws-observability/aws-otel-collector:latest
-COPY otel-config.yaml /cloud/aws/metrics/otel-config.yaml
-CMD ["--config=/cloud/aws/metrics/otel-config.yaml"]
+COPY otel-config.yaml /etc/ecs/otel-config.yaml
+CMD ["--config=/etc/ecs/otel-config.yaml"]

--- a/cloud/aws/metrics/metrics_scraper.Dockerfile
+++ b/cloud/aws/metrics/metrics_scraper.Dockerfile
@@ -1,3 +1,3 @@
 FROM public.ecr.aws/aws-observability/aws-otel-collector:latest
-COPY otel-config.yaml /etc/ecs/otel-config.yaml
-CMD ["--config=/etc/ecs/otel-config.yaml"]
+COPY otel-config.yaml /cloud/aws/metrics/otel-config.yaml
+CMD ["--config=/cloud/aws/metrics/otel-config.yaml"]

--- a/cloud/aws/metrics/otel-config.yaml
+++ b/cloud/aws/metrics/otel-config.yaml
@@ -1,0 +1,59 @@
+# This file configures the AWS Distro for OpenTelemetry, which implements metrics scraping in the
+# CiviForm monitoring stack. For more info see https://aws.amazon.com/otel and
+# https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-ingest-metrics-OpenTelemetry-ECS.html
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'civiform_scraper'
+          static_configs:
+            - targets: [0.0.0.0:9000]
+  awsecscontainermetrics:
+    collection_interval: 10s
+
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.utilized
+          - ecs.task.memory.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+
+exporters:
+  prometheusremotewrite:
+    endpoint: '${PROMETHEUS_WRITE_ENDPOINT}'
+    auth:
+      authenticator: sigv4auth
+  logging:
+    loglevel: info
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+  sigv4auth:
+    region: '${AWS_REGION}'
+    service: aps
+
+service:
+  extensions: [pprof, zpages, health_check, sigv4auth]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [logging, prometheusremotewrite]
+    metrics/ecs:
+      receivers: [awsecscontainermetrics]
+      processors: [filter]
+      exporters: [logging, prometheusremotewrite]


### PR DESCRIPTION
When the metrics scraper actions were moved into the infrastructure directory, the [otel-config file](https://github.com/civiform/civiform/blob/main/otel-config.yaml) wasn't brought over. Copied this over, so we can push the docker image with the config changes we made. I'll remove this file from the other directory as a follow up.

Here is the dockerfile that references this config: https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/aws/metrics/metrics_scraper.Dockerfile

Related to https://github.com/civiform/civiform/issues/4789