### PR TITLE
Create github action to push metrics scraper

### DIFF
--- a/.github/workflows/push_monitoring_image.yaml
+++ b/.github/workflows/push_monitoring_image.yaml
@@ -1,0 +1,43 @@
+name: build_push_metrics_scraper_image
+
+on:
+  push:
+    branches: 
+    - main
+  # Setting this enables manually triggering workflow in the GitHub UI
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch: {}
+
+permissions: read-all
+
+# Build and push the monitoring image.
+jobs:
+  build_civiform_cloud_deployment:
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: build-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    name: Build civiform-cloud-deployment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up Docker QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Run build
+        id: build_and_push_monitoring
+        env:
+          DOCKER_BUILDKIT: 1
+          PLATFORM: 'linux/amd64'
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+        run: |
+          cd $GITHUB_WORKSPACE/civiform-cloud-deploy-infra/cloud/aws/metrics
+          | ./build-scraper

--- a/.github/workflows/push_monitoring_image.yaml
+++ b/.github/workflows/push_monitoring_image.yaml
@@ -27,8 +27,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Run build

--- a/.github/workflows/push_monitoring_image.yaml
+++ b/.github/workflows/push_monitoring_image.yaml
@@ -27,6 +27,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - id: file_changes
+        uses: tj-actions/changed-files@v35
+        with:
+          json: 'true'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Run build
@@ -36,6 +40,7 @@ jobs:
           PLATFORM: 'linux/amd64'
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+        if: contains(toJSON(steps.file_changes.outputs.all_changed_files), 'cloud/aws/metrics/')
         run: |
           cd $GITHUB_WORKSPACE/civiform-cloud-deploy-infra/cloud/aws/metrics
           | ./build-scraper

--- a/cloud/aws/metrics/build-scraper
+++ b/cloud/aws/metrics/build-scraper
@@ -2,23 +2,23 @@
 
 # Builds the prometheus metrics scraper Docker image
 
+set -e
+set +x
+
 readonly SHORT_SHA="$(git rev-parse --short HEAD)"
 readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
 readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
 readonly IMAGE="aws-metrics-scraper"
 
 PLATFORM_ARG=()
-if [[ "${PLATFORM}" ]]; then
+if [[ -n "${PLATFORM}" ]]; then
   PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
-
-set -e
-set +x
 
 echo "start ${IMAGE} build"
 docker buildx create --use
 docker buildx build \
   "${PLATFORM_ARG[@]}" --push \
-  -t docker.io/civiform/${IMAGE}:latest \
-  -t docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG} \
+  -t "docker.io/civiform/${IMAGE}:latest" \
+  -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
   -f metrics_scraper.Dockerfile .

--- a/cloud/aws/metrics/build-scraper
+++ b/cloud/aws/metrics/build-scraper
@@ -14,11 +14,12 @@ PLATFORM_ARG=()
 if [[ -n "${PLATFORM}" ]]; then
   PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
+readonly PLATFORM_ARG
 
 echo "start ${IMAGE} build"
 docker buildx create --use
-docker buildx build \
-  "${PLATFORM_ARG[@]}" --push \
+docker buildx build --push \
+  "${PLATFORM_ARG[@]}" \
   -t "docker.io/civiform/${IMAGE}:latest" \
   -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
   -f metrics_scraper.Dockerfile .

--- a/cloud/aws/metrics/build-scraper
+++ b/cloud/aws/metrics/build-scraper
@@ -2,8 +2,23 @@
 
 # Builds the prometheus metrics scraper Docker image
 
-docker build \
-  -t docker.io/civiform/aws-metrics-scraper:latest \
-  -f metrics_scraper.Dockerfile .
+readonly SHORT_SHA="$(git rev-parse --short HEAD)"
+readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
+readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
+readonly IMAGE="aws-metrics-scraper"
 
-docker push docker.io/civiform/aws-metrics-scraper:latest
+PLATFORM_ARG=()
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG=(--platform "${PLATFORM}")
+fi
+
+set -e
+set +x
+
+echo "start ${IMAGE} build"
+docker buildx create --use
+docker buildx build \
+  "${PLATFORM_ARG[@]}" --push \
+  -t docker.io/civiform/${IMAGE}:latest \
+  -t docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG} \
+  -f metrics_scraper.Dockerfile .


### PR DESCRIPTION
Add a github action to push the metrics scraper image

This is similar to https://github.com/civiform/cloud-deploy-infra/blob/main/.github/workflows/build_push_image.yaml

This also updates the metrics scraper docker image to add a tag when pushed for better versioning.

Related to fixing https://github.com/civiform/civiform/issues/4789