### PR TITLE
Remove version of var that has a typo

### DIFF
--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -213,12 +213,6 @@
     "tfvar": true,
     "type": "bool"
   },
-  "NONGATED_ELIGIBLITY_ENABLED": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "bool"
-  },
   "COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT": {
     "required": false,
     "secret": false,


### PR DESCRIPTION
There's another entry with the correct spelling. NONGATED_ELIGIBLITY_ENABLED vs. NONGATED_ELIGIBILITY_ENABLED