### PR TITLE
fix file path and pass all args along to run.py

### DIFF
--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -12,20 +12,8 @@
 # To get access to the package, we create a python virtual environment(venv), install the package and
 # activate the venv. The activation has to happen in the parent process before the python code is run.
 # This is why we need a bash script that preceeds the python code
-source cloud/shared/bin/python-env_setup
+source cloud/shared/bin/python_env_setup
 # TODO(#4612)Download the newest version of the package rather than a fixed version.
 initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt
 
-# Get the arguments that we want to pass to run.py
-while getopts s:c:t: flag; do
-  case "${flag}" in
-    # The civiform_config file that contains the values to configure the deployment
-    s) sourceconfig=${OPTARG} ;;
-    # The command that the run.py script should execute
-    c) command=${OPTARG} ;;
-    # The tag of the image that should be used for this deployment (e.g. "latest")
-    t) tag=${OPTARG} ;;
-  esac
-done
-
-cloud/shared/bin/run.py --command $command --tag $tag --config $sourceconfig
+cloud/shared/bin/run.py "$@"


### PR DESCRIPTION
This pr fixes a couple of issues that were preventing this script from running:
1. there was a typo in the file path for `python_env_setup`
2. arguments were not being passed along to `run.py`

I tested this locally and confirmed the python package is downloaded and `run.py` successfully runs.