### PR TITLE
fix SKIP_CONFIRMATIONS deploy bug

### DIFF
--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -342,7 +342,7 @@ class ConfigLoader:
 
     @property
     def skip_confirmations(self):
-        return self._config_fields.get("SKIP_CONFIRMATIONS", False)
+        return os.getenv("SKIP_CONFIRMATIONS", False)
 
     def get_config_var(self, variable_name):
         return self._config_fields.get(variable_name)


### PR DESCRIPTION
`SKIP_CONFIRMATIONS` is a variable used by Terraform to know whether or not is should expect a "yes" before applying the terraform plan. 

In our [AWS staging deploy](https://github.com/civiform/civiform-staging-deploy/blob/2fe8d93dc1413724d451a7ce1d035c66c3bbe472/.github/workflows/aws_deploy.yaml#LL28C7-L28C25) (and likely other deployments) this is set to true so Terraform will not wait for a confirmation before applying the changes.

[This PR](https://github.com/civiform/cloud-deploy-infra/pull/132) updated several environment variables to be read from the config instead of `os.env`, including `SKIP_CONFIRMATIONS`. Merging this PR caused our staging deployment to fail with an error message that said `error asking for approval`. Some googling led me to understand this error is related to Terraform not receiving the "yes" it needs to continue. 

Digging deeper in the PR linked above, I realized that, unlike other variables update to be read from the config file, `SKIP_CONFIRMATIONS` is not set in the config file nor anywhere else in our deploy code. I believe this means it was defaulting to a "false" value and not able to read the "true" value we set in our github workflow for staging deploy.

Note: I also looked into the other variables in the PR linked above that are being updated to be read from the config file and I don't think any of them will be an issue. These are:
- USE_LOCAL_BACKEND - reset to read from the config file in the test [here](https://github.com/civiform/cloud-deploy-infra/blob/4e184422f7aac5d0586a88390424e938d50622ce/.github/workflows/aws-oidc-deploy-test.yaml#L40). i'm not sure how else this var might be used in deployments. need to find that out.
- AWS_REGION - set in individual config files or [defaults to 'us-east-1'](https://github.com/civiform/cloud-deploy-infra/blob/4e184422f7aac5d0586a88390424e938d50622ce/cloud/shared/bin/lib/config_loader.py#L330)
- CIVIFORM_MODE - set in [individual config files](https://github.com/civiform/civiform-staging-deploy/blob/2fe8d93dc1413724d451a7ce1d035c66c3bbe472/aws_staging_civiform_config.sh#L28)
- TF_VAR_FILENAME - hardcoded [here](https://github.com/civiform/cloud-deploy-infra/blob/4e184422f7aac5d0586a88390424e938d50622ce/cloud/shared/bin/lib.sh#L6) now
- BACKEND_VARS_FILENAME - hardcoded [here](https://github.com/civiform/cloud-deploy-infra/blob/4e184422f7aac5d0586a88390424e938d50622ce/cloud/shared/bin/lib.sh#L8) now
- APP_PREFIX - set in [individual config files](https://github.com/civiform/civiform-staging-deploy/blob/2fe8d93dc1413724d451a7ce1d035c66c3bbe472/aws_staging_civiform_config.sh#L125)

If you see an issue with how any of these are referenced please let me know and I can update it! 