### PR TITLE
Update description and setting of eligibility flag

### DIFF
--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -381,8 +381,8 @@ variable "staging_disable_applicant_guest_login" {
 }
 variable "program_eligibility_conditions_enabled" {
   type        = bool
-  description = "Whether to enable program eligibility conditions"
-  default     = false
+  description = "Whether to enable program eligibility conditions. This feature flag has been removed, so this will be enabled by default for all deployments after v1.26.0."
+  default     = true
 }
 variable "intake_form_enabled" {
   type        = bool


### PR DESCRIPTION
We removed the eligibility feature flag in https://github.com/civiform/civiform/pull/4879. This updates the description and setting of the variable in the deploy infra repo. I'll plan to remove this variable in a couple of weeks.

Related to: https://github.com/civiform/civiform/issues/4605