### PR TITLE
download correct version of parser package for civiform version

### DIFF
--- a/cloud/shared/bin/env-var-docs-python-dependencies.txt
+++ b/cloud/shared/bin/env-var-docs-python-dependencies.txt
@@ -1,2 +1,1 @@
-env-var-docs @ git+https://github.com/civiform/civiform.git@3af899747eee36c2cd05892a0067dd5843b923f3#subdirectory=env-var-docs/parser-package
 requests==2.31.0

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -32,11 +32,12 @@ if [ $tag == "latest" ]; then
     | python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
 fi
 
-# Get the correct version of the env-var-docs/parser-package and write it to the dependencies file for installation
+# Get the commit sha for the commit at the tip of the CiviForm version being deployed
 tag_url=$(curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
   | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])")
 commit_sha=$(curl -s "${tag_url}" \
   | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])")
+# Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded
 echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >>"cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
 initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -28,16 +28,16 @@ done
 
 # If tag is "latest" get the latest release number (eg. v1.26.0)
 if [ $tag == "latest" ]; then
-  tag=`curl -s "https://api.github.com/repos/civiform/civiform/releases/latest" | \
-    python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])"`
+  tag=$(curl -s "https://api.github.com/repos/civiform/civiform/releases/latest" \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
 fi
 
 # Get the correct version of the env-var-docs/parser-package and write it to the dependencies file for installation
-tag_url=`curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" | \
-    python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])"`
-commit_sha=`curl -s "${tag_url}" | \
-    python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])"`
-echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >> "cloud/shared/bin/env-var-docs-python-dependencies.txt"
+tag_url=$(curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])")
+commit_sha=$(curl -s "${tag_url}" \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])")
+echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >>"cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
 initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt
 

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -41,8 +41,8 @@ fi
 #   Value found at the specified path in the JSON document
 #######################################
 function fetch_json_val() {
-  curl -s "${1}" \ |
-    python3 -c "import sys, json; print(json.load(sys.stdin)${2})"
+  curl -s "${1}" \  \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)${2})"
 }
 
 # Get the commit sha for the commit at the tip of the CiviForm version being deployed
@@ -52,7 +52,7 @@ commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
 dependencies_file_path="cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
 # Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded
-echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package">>$dependencies_file_path
+echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >>$dependencies_file_path
 
 initialize_python_env $dependencies_file_path
 

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -49,9 +49,11 @@ function fetch_json_val() {
 tag_url=$(fetch_json_val "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" "['object']['url']")
 commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
 
-# Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded
-echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >>"cloud/shared/bin/env-var-docs-python-dependencies.txt"
+dependencies_file_path="cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
-initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt
+# Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded
+echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package">>${dependencies_file_path}
+
+initialize_python_env ${dependencies_file_path}
 
 cloud/shared/bin/run.py --command $command --tag $tag --config $source_config

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -46,15 +46,12 @@ function fetch_json_val() {
 }
 
 # Get the commit sha for the commit at the tip of the CiviForm version being deployed
-tag_url=fetch_json_val "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" "['object']['url']"
+tag_url=$(fetch_json_val "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" "['object']['url']")
+commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
 
-# $(curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
-#   | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])")
-commit_sha=$(curl -s "${tag_url}" \
-  | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])")
 # Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded
 echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >>"cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
 initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt
 
-cloud/shared/bin/run.py --command $command --tag $tag --config $sourceconfig
+cloud/shared/bin/run.py --command $command --tag $tag --config $source_config

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -18,7 +18,7 @@ source cloud/shared/bin/python_env_setup
 while getopts s:c:t: flag; do
   case "${flag}" in
     # The civiform_config file that contains the values to configure the deployment
-    s) sourceconfig=${OPTARG} ;;
+    s) source_config=${OPTARG} ;;
     # The command that the run.py script should execute
     c) command=${OPTARG} ;;
     # The tag of the image that should be used for this deployment (e.g. "latest")

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -52,8 +52,8 @@ commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
 dependencies_file_path="cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
 # Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded
-echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package">>${dependencies_file_path}
+echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package">>$dependencies_file_path
 
-initialize_python_env ${dependencies_file_path}
+initialize_python_env $dependencies_file_path
 
 cloud/shared/bin/run.py --command $command --tag $tag --config $source_config

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -26,25 +26,17 @@ while getopts s:c:t: flag; do
   esac
 done
 
-echo "TAG BEFORE REASSIGNMENT"
-echo $tag
-
-# need to handle "latest" case
+# If tag is "latest" get the latest release number (eg. v1.26.0)
 if [ $tag == "latest" ]; then
   tag=`curl -s "https://api.github.com/repos/civiform/civiform/releases/latest" | \
     python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])"`
 fi
 
-echo "TAG AFTER REASSIGNMENT"
-echo $tag
-
 # Get the correct version of the env-var-docs/parser-package and write it to the dependencies file for installation
 tag_url=`curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" | \
     python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])"`
-echo $tag_url
 commit_sha=`curl -s "${tag_url}" | \
     python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])"`
-echo $commit_sha
 echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >> "cloud/shared/bin/env-var-docs-python-dependencies.txt"
 
 initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -32,9 +32,24 @@ if [[ ${tag} == "latest" ]]; then
     | python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
 fi
 
+#######################################
+# Get the value in a JSON document at the given URL.
+# Arguments:
+#   1: URL of the JSON document
+#   2: Path of the value in bracket notation e.g. "['object']['sha']"
+# Returns:
+#   Value found at the specified path in the JSON document
+#######################################
+function fetch_json_val() {
+  curl -s "${1}" \ |
+    python3 -c "import sys, json; print(json.load(sys.stdin)${2})"
+}
+
 # Get the commit sha for the commit at the tip of the CiviForm version being deployed
-tag_url=$(curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
-  | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])")
+tag_url=fetch_json_val "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" "['object']['url']"
+
+# $(curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
+#   | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])")
 commit_sha=$(curl -s "${tag_url}" \
   | python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])")
 # Write the correct version of the env-var-docs/parser-package to the dependencies file to be downloaded

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -27,7 +27,7 @@ while getopts s:c:t: flag; do
 done
 
 # If tag is "latest" get the latest release number (eg. v1.26.0)
-if [ $tag == "latest" ]; then
+if [[ ${tag} == "latest" ]]; then
   tag=$(curl -s "https://api.github.com/repos/civiform/civiform/releases/latest" \
     | python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
 fi

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -13,7 +13,40 @@
 # activate the venv. The activation has to happen in the parent process before the python code is run.
 # This is why we need a bash script that preceeds the python code
 source cloud/shared/bin/python_env_setup
-# TODO(#4612)Download the newest version of the package rather than a fixed version.
+
+# Get the arguments that we want to pass to run.py
+while getopts s:c:t: flag; do
+  case "${flag}" in
+    # The civiform_config file that contains the values to configure the deployment
+    s) sourceconfig=${OPTARG} ;;
+    # The command that the run.py script should execute
+    c) command=${OPTARG} ;;
+    # The tag of the image that should be used for this deployment (e.g. "latest")
+    t) tag=${OPTARG} ;;
+  esac
+done
+
+echo "TAG BEFORE REASSIGNMENT"
+echo $tag
+
+# need to handle "latest" case
+if [ $tag == "latest" ]; then
+  tag=`curl -s "https://api.github.com/repos/civiform/civiform/releases/latest" | \
+    python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'])"`
+fi
+
+echo "TAG AFTER REASSIGNMENT"
+echo $tag
+
+# Get the correct version of the env-var-docs/parser-package and write it to the dependencies file for installation
+tag_url=`curl -s "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" | \
+    python3 -c "import sys, json; print(json.load(sys.stdin)['object']['url'])"`
+echo $tag_url
+commit_sha=`curl -s "${tag_url}" | \
+    python3 -c "import sys, json; print(json.load(sys.stdin)['object']['sha'])"`
+echo $commit_sha
+echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}#subdirectory=env-var-docs/parser-package" >> "cloud/shared/bin/env-var-docs-python-dependencies.txt"
+
 initialize_python_env cloud/shared/bin/env-var-docs-python-dependencies.txt
 
-cloud/shared/bin/run.py "$@"
+cloud/shared/bin/run.py --command $command --tag $tag --config $sourceconfig


### PR DESCRIPTION
Now that [we have logic](https://github.com/civiform/cloud-deploy-infra/pull/154) to pull in the correct version of `env-var-docs.json` for the version of CiviForm being deployed, we need to make sure we're pulling in the correct version of the parser package as well.

This change adds logic to the `run` script to fetch the correct version of the parser package via the Github api based on the version of CiviForm being deployed.

I tested it locally by deploying with different versions (v1.24.0 and "latest") and confirming that different versions of the parser packaged were downloaded.