### PR TITLE
Turn server var autogeneration on for all

### DIFF
--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -19,6 +19,8 @@ _CIVIFORM_RELEASE_TAG_REGEX = re.compile(r'^v?[0-9]+\.[0-9]+\.[0-9]+$')
 
 
 def main():
+    _overwrite_checkout_file()
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--tag', help='Civiform image tag. Required for Setup and Deploy.')
@@ -97,6 +99,18 @@ def normalize_tag(tag):
         return f'v{tag}'
     return tag
 
+def _overwrite_checkout_file():
+    # Read in the file
+    with open('../bin/lib/checkout.sh', 'r') as file :
+        filedata = file.read()
+
+    # Replace args and command path name
+    filedata = filedata.replace('args=("--command=${CMD_NAME}" "--tag=${CIVIFORM_VERSION}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")', 'args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")')
+    filedata = filedata.replace('CMD_NAME_PATH="cloud/shared/bin/run.py"', 'CMD_NAME_PATH="cloud/shared/bin/run"')
+
+    # Write the file out again
+    with open('../bin/lib/checkout.sh', 'w') as file:
+        file.write(filedata)
 
 if __name__ == "__main__":
     main()

--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -19,7 +19,8 @@ _CIVIFORM_RELEASE_TAG_REGEX = re.compile(r'^v?[0-9]+\.[0-9]+\.[0-9]+$')
 
 
 def main():
-    _overwrite_checkout_file()
+    if not os.getenv("GITHUB_ACTIONS") == "true":
+        _overwrite_checkout_file()
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -99,18 +99,25 @@ def normalize_tag(tag):
         return f'v{tag}'
     return tag
 
+
 def _overwrite_checkout_file():
     # Read in the file
-    with open('../bin/lib/checkout.sh', 'r') as file :
+    with open('../bin/lib/checkout.sh', 'r') as file:
         filedata = file.read()
 
     # Replace args and command path name
-    filedata = filedata.replace('args=("--command=${CMD_NAME}" "--tag=${CIVIFORM_VERSION}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")', 'args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")')
-    filedata = filedata.replace('CMD_NAME_PATH="cloud/shared/bin/run.py"', 'CMD_NAME_PATH="cloud/shared/bin/run"')
+    filedata = filedata.replace(
+        'args=("--command=${CMD_NAME}" "--tag=${CIVIFORM_VERSION}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")',
+        'args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")'
+    )
+    filedata = filedata.replace(
+        'CMD_NAME_PATH="cloud/shared/bin/run.py"',
+        'CMD_NAME_PATH="cloud/shared/bin/run"')
 
     # Write the file out again
     with open('../bin/lib/checkout.sh', 'w') as file:
         file.write(filedata)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Once we are ready to start using the new system of auto-generating server vars, we can merge this to overwrite the calls to [run.py](https://github.com/civiform/civiform-deploy/blob/9f277338e676b7d8a2b27795a51cbdc83c69f703/bin/lib/checkout.sh#L68) in local copies of `civiform-deploy` with calls to [bin/run](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/shared/bin/run).

The first time a CE deploys after this change is merged, their local code will be updated to call the new `run` script with the updated arguments. The time they deploy after that, their deployment will use the new path with auto-generated server vars.

Note: I had to add a check for if the env is Github Actions to get tests to pass. We should make sure folks aren't deploying via Github Actions (like we are on staging) or this change won't get picked up for them.