### PR TITLE
add option to pass in snapshot tag

### DIFF
--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -116,7 +116,8 @@ class ConfigLoader:
 
         # Download the env-var-docs.json if there is a version that corresponds to the
         # civiform version of this deployment.
-        env_var_docs = self._download_env_var_docs(self.get_civiform_image_tag_or_version())
+        env_var_docs = self._download_env_var_docs(
+            self.get_civiform_image_tag_or_version())
         if env_var_docs is None:
             return {}
 
@@ -403,7 +404,8 @@ class ConfigLoader:
         if v is None:
             v = self._config_fields.get("CIVIFORM_VERSION")
             if v is None:
-                exit("CIVIFORM_VERSION is required to be set in the config file")
+                exit(
+                    "CIVIFORM_VERSION is required to be set in the config file")
         return v
 
     def get_template_dir(self):

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -42,7 +42,7 @@ function fetch_json_val() {
 
 commit_sha=""
 
-# In a snapshot tag, eg. "SNAPSHOT-920bc49-1685642238", the middle section is the 
+# In a snapshot tag, eg. "SNAPSHOT-920bc49-1685642238", the middle section is the
 # shortened commit sha. Use this to get the full commit sha.
 if [[ ${tag} == *"SNAPSHOT"* ]]; then
   splitTag=(${tag//-/ })

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -40,18 +40,27 @@ function fetch_json_val() {
     | python3 -c "import sys, json; print(json.load(sys.stdin)${2})"
 }
 
-# If tag is "latest" get the latest release number (eg. v1.26.0)
-if [[ ${tag} == "latest" ]]; then
-  tag=$(fetch_json_val \
-    "https://api.github.com/repos/civiform/civiform/releases/latest" \
-    "['tag_name']")
-fi
+commit_sha=""
 
-# Get the commit sha for the commit at the tip of the CiviForm version being deployed
-tag_url=$(fetch_json_val \
-  "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
-  "['object']['url']")
-commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
+# In a snapshot tag, eg. "SNAPSHOT-920bc49-1685642238", the middle section is the 
+# shortened commit sha. Use this to get the full commit sha.
+if [[ ${tag} == *"SNAPSHOT"* ]]; then
+  splitTag=(${tag//-/ })
+  short_sha=${splitTag[1]}
+  commit_sha=$(fetch_json_val "https://api.github.com/repos/civiform/civiform/commits/${short_sha}" "['sha']")
+else
+  # If tag is "latest" get the latest release number (eg. v1.26.0)
+  if [[ ${tag} == "latest" ]]; then
+    tag=$(fetch_json_val \
+      "https://api.github.com/repos/civiform/civiform/releases/latest" \
+      "['tag_name']")
+  fi
+  # Get the commit sha for the commit at the tip of the CiviForm version being deployed
+  tag_url=$(fetch_json_val \
+    "https://api.github.com/repos/civiform/civiform/git/refs/tags/${tag}" \
+    "['object']['url']")
+  commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
+fi
 
 dependencies_file_path="cloud/shared/bin/env-var-docs-python-dependencies.txt"
 


### PR DESCRIPTION
Previously, we were making the assumption that the only values passed into the deploy script would be "latest" or a version number (eg. "v1.25.0"). Our staging deployment, however, [passes in a specific snapshot tag](https://github.com/civiform/civiform-staging-deploy/blob/cfa775287b1675069521e0c835c03e0031f61222/.github/workflows/aws_deploy.yaml#L53).

This PR adds logic to handle downloading the correct versions of the env-vars-parser package and env-var-docs.json when deploying with a snapshot tag.

Related to https://github.com/civiform/civiform/issues/4612