### PR TITLE
Use app_prefix instead of name_prefix for ecs_fargate_service

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -353,7 +353,7 @@ resource "aws_ecs_task_definition" "td" {
 module "ecs_fargate_service" {
   source                  = "cn-terraform/ecs-fargate-service/aws"
   version                 = "2.0.39"
-  name_prefix             = "${var.app_prefix}-civiform"
+  name_prefix             = var.app_prefix
   desired_count           = var.fargate_desired_task_count
   default_certificate_arn = var.ssl_certificate_arn
   ssl_policy              = "ELBSecurityPolicy-FS-1-2-Res-2020-10"

--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -19,8 +19,8 @@ POSTGRES_PASSWORD = 'civiform_postgres_password'
 DATABASE = 'civiform-db'
 
 # Defined by fargate modules in cloud/aws/templates/aws_oidc/app.tf
-FARGATE_SERVICE = 'civiform-service'
-LOAD_BALANCER = 'civiform-lb'
+FARGATE_SERVICE = 'service'
+LOAD_BALANCER = 'lb'
 CLUSTER = 'civiform'
 
 # Defined in cloud/aws/modules/setup/backend_storage.tf


### PR DESCRIPTION
By appending -civiform to the app_prefix, we were often hitting the AWS 32 character limit.