### PR TITLE
Use new ECS variables

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -351,22 +351,29 @@ resource "aws_ecs_task_definition" "td" {
 }
 
 module "ecs_fargate_service" {
-  source                  = "cn-terraform/ecs-fargate-service/aws"
-  version                 = "2.0.39"
-  name_prefix             = "${var.app_prefix}-civiform"
-  desired_count           = var.fargate_desired_task_count
-  default_certificate_arn = var.ssl_certificate_arn
-  ssl_policy              = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
-  vpc_id                  = module.vpc.vpc_id
-  task_definition_arn     = aws_ecs_task_definition.td.arn
-  container_name          = "${var.app_prefix}-civiform"
-  ecs_cluster_name        = module.ecs_cluster.aws_ecs_cluster_cluster_name
-  ecs_cluster_arn         = module.ecs_cluster.aws_ecs_cluster_cluster_arn
-  private_subnets         = module.vpc.private_subnets
-  public_subnets          = module.vpc.public_subnets
-  enable_s3_logs          = false
-  max_cpu_threshold       = var.ecs_max_cpu_threshold
-  min_cpu_threshold       = var.ecs_min_cpu_threshold
+  source                    = "cn-terraform/ecs-fargate-service/aws"
+  version                   = "2.0.39"
+  name_prefix               = "${var.app_prefix}-civiform"
+  desired_count             = var.fargate_desired_task_count
+  default_certificate_arn   = var.ssl_certificate_arn
+  ssl_policy                = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  vpc_id                    = module.vpc.vpc_id
+  task_definition_arn       = aws_ecs_task_definition.td.arn
+  container_name            = "${var.app_prefix}-civiform"
+  ecs_cluster_name          = module.ecs_cluster.aws_ecs_cluster_cluster_name
+  ecs_cluster_arn           = module.ecs_cluster.aws_ecs_cluster_cluster_arn
+  private_subnets           = module.vpc.private_subnets
+  public_subnets            = module.vpc.public_subnets
+  enable_s3_logs            = false
+  max_cpu_threshold         = var.ecs_max_cpu_threshold
+  min_cpu_threshold         = var.ecs_min_cpu_threshold
+  max_cpu_evaluation_period = var.ecs_max_cpu_evaluation_period
+  min_cpu_evaluation_period = var.ecs_min_cpu_evaluation_period
+  max_cpu_period            = var.ecs_max_cpu_period
+  min_cpu_period            = var.ecs_min_cpu_period
+  scale_target_max_capacity = var.ecs_scale_target_max_capacity
+  scale_target_min_capacity = var.ecs_scale_target_min_capacity
+
 
   lb_http_ports = {
     default_http = {


### PR DESCRIPTION
This includes using the following:
- max_cpu_evaluation_period
- min_cpu_evaluation_period
- max_cpu_period
- min_cpu_period 
- scale_target_max_capacity
- scale_target_min_capacity

Related to: https://github.com/civiform/civiform/issues/5078