### PR TITLE
Add threshold variables for RDS alarms

### DIFF
--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -64,28 +64,29 @@ data "aws_db_instance" "civiform" {
 }
 
 module "aws-rds-alarms" {
-  source                                    = "lorenzoaiello/rds-alarms/aws"
-  version                                   = "2.2.0"
-  db_instance_id                            = data.aws_db_instance.civiform.id
-  db_instance_class                         = var.postgres_instance_class
-  engine                                    = "postgres"
-  evaluation_period                         = var.rds_alarm_evaluation_period
-  statistic_period                          = var.rds_alarm_statistic_period
-  create_high_cpu_alarm                     = var.rds_create_high_cpu_alarm
-  cpu_utilization_too_high_threshold        = var.rds_max_cpu_utilization_threshold
-  create_high_queue_depth_alarm             = var.rds_create_high_queue_depth_alarm
-  disk_queue_depth_too_high_threshold       = var.rds_disk_queue_depth_high_threshold
-  create_low_disk_space_alarm               = var.rds_create_low_disk_space_alarm
-  disk_free_storage_space_too_low_threshold = var.rds_disk_free_storage_low_threshold
-  create_low_memory_alarm                   = var.rds_create_low_memory_alarm
-  memory_freeable_too_low_threshold         = var.rds_low_memory_threshold
-  create_low_cpu_credit_alarm               = var.rds_create_low_cpu_credit_alarm
-  cpu_credit_balance_too_low_threshold      = var.rds_low_cpu_credit_balance_threshold
-  create_low_disk_burst_alarm               = var.rds_create_low_disk_burst_alarm
-  disk_burst_balance_too_low_threshold      = var.rds_disk_burst_balance_low_threshold
-  create_swap_alarm                         = var.rds_create_swap_alarm
-  memory_swap_usage_too_high_threshold      = var.rds_high_swap_usage_threshold
-  create_anomaly_alarm                      = var.rds_create_anomaly_alarm
+  source                                          = "lorenzoaiello/rds-alarms/aws"
+  version                                         = "2.2.0"
+  db_instance_id                                  = data.aws_db_instance.civiform.id
+  db_instance_class                               = var.postgres_instance_class
+  engine                                          = "postgres"
+  evaluation_period                               = var.rds_alarm_evaluation_period
+  statistic_period                                = var.rds_alarm_statistic_period
+  create_high_cpu_alarm                           = var.rds_create_high_cpu_alarm
+  cpu_utilization_too_high_threshold              = var.rds_max_cpu_utilization_threshold
+  create_high_queue_depth_alarm                   = var.rds_create_high_queue_depth_alarm
+  disk_queue_depth_too_high_threshold             = var.rds_disk_queue_depth_high_threshold
+  create_low_disk_space_alarm                     = var.rds_create_low_disk_space_alarm
+  disk_free_storage_space_too_low_threshold       = var.rds_disk_free_storage_low_threshold
+  create_low_memory_alarm                         = var.rds_create_low_memory_alarm
+  memory_freeable_too_low_threshold               = var.rds_low_memory_threshold
+  create_low_cpu_credit_alarm                     = var.rds_create_low_cpu_credit_alarm
+  cpu_credit_balance_too_low_threshold            = var.rds_low_cpu_credit_balance_threshold
+  create_low_disk_burst_alarm                     = var.rds_create_low_disk_burst_alarm
+  disk_burst_balance_too_low_threshold            = var.rds_disk_burst_balance_low_threshold
+  create_swap_alarm                               = var.rds_create_swap_alarm
+  memory_swap_usage_too_high_threshold            = var.rds_high_swap_usage_threshold
+  create_anomaly_alarm                            = var.rds_create_anomaly_alarm
+  maximum_used_transaction_ids_too_high_threshold = var.rds_max_used_transaction_ids_high_threshold
 }
 
 module "email_service" {

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -64,18 +64,28 @@ data "aws_db_instance" "civiform" {
 }
 
 module "aws-rds-alarms" {
-  source                        = "lorenzoaiello/rds-alarms/aws"
-  version                       = "2.2.0"
-  db_instance_id                = data.aws_db_instance.civiform.id
-  db_instance_class             = var.postgres_instance_class
-  create_high_cpu_alarm         = var.rds_create_high_cpu_alarm
-  create_high_queue_depth_alarm = var.rds_create_high_queue_depth_alarm
-  create_low_disk_space_alarm   = var.rds_create_low_disk_space_alarm
-  create_low_memory_alarm       = var.rds_create_low_memory_alarm
-  create_low_cpu_credit_alarm   = var.rds_create_low_cpu_credit_alarm
-  create_low_disk_burst_alarm   = var.rds_create_low_disk_burst_alarm
-  create_swap_alarm             = var.rds_create_swap_alarm
-  create_anomaly_alarm          = var.rds_create_anomaly_alarm
+  source                                    = "lorenzoaiello/rds-alarms/aws"
+  version                                   = "2.2.0"
+  db_instance_id                            = data.aws_db_instance.civiform.id
+  db_instance_class                         = var.postgres_instance_class
+  engine                                    = "postgres"
+  evaluation_period                         = var.rds_alarm_evaluation_period
+  statistic_period                          = var.rds_alarm_statistic_period
+  create_high_cpu_alarm                     = var.rds_create_high_cpu_alarm
+  cpu_utilization_too_high_threshold        = var.rds_max_cpu_utilization_threshold
+  create_high_queue_depth_alarm             = var.rds_create_high_queue_depth_alarm
+  disk_queue_depth_too_high_threshold       = var.rds_disk_queue_depth_high_threshold
+  create_low_disk_space_alarm               = var.rds_create_low_disk_space_alarm
+  disk_free_storage_space_too_low_threshold = var.rds_disk_free_storage_low_threshold
+  create_low_memory_alarm                   = var.rds_create_low_memory_alarm
+  memory_freeable_too_low_threshold         = var.rds_low_memory_threshold
+  create_low_cpu_credit_alarm               = var.rds_create_low_cpu_credit_alarm
+  cpu_credit_balance_too_low_threshold      = var.rds_low_cpu_credit_balance_threshold
+  create_low_disk_burst_alarm               = var.rds_create_low_disk_burst_alarm
+  disk_burst_balance_too_low_threshold      = var.rds_disk_burst_balance_low_threshold
+  create_swap_alarm                         = var.rds_create_swap_alarm
+  memory_swap_usage_too_high_threshold      = var.rds_high_swap_usage_threshold
+  create_anomaly_alarm                      = var.rds_create_anomaly_alarm
 }
 
 module "email_service" {

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -293,6 +293,12 @@
     "tfvar": true,
     "type": "string"
   },
+  "RDS_MAX_USED_TRANSACTION_IDS_HIGH_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "RDS_CREATE_ANOMALY_ALARM": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -197,11 +197,29 @@
     "tfvar": true,
     "type": "string"
   },
+  "RDS_ALARM_EVALUATION_PERIOD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "RDS_ALARM_STATISTIC_PERIOD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "RDS_CREATE_HIGH_CPU_ALARM": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "RDS_MAX_CPU_UTILIZATION_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   },
   "RDS_CREATE_HIGH_QUEUE_DEPTH_ALARM": {
     "required": false,
@@ -209,11 +227,23 @@
     "tfvar": true,
     "type": "bool"
   },
+  "RDS_DISK_QUEUE_DEPTH_HIGH_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "RDS_CREATE_LOW_DISK_SPACE_ALARM": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "RDS_DISK_FREE_STORAGE_LOW_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   },
   "RDS_CREATE_LOW_MEMORY_SPACE_ALARM": {
     "required": false,
@@ -221,11 +251,23 @@
     "tfvar": true,
     "type": "bool"
   },
+  "RDS_LOW_MEMORY_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "RDS_CREATE_LOW_CPU_CREDIT_ALARM": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "RDS_LOW_CPU_CREDIT_BALANCE_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   },
   "RDS_CREATE_LOW_DISK_BURST_ALARM": {
     "required": false,
@@ -233,11 +275,23 @@
     "tfvar": true,
     "type": "bool"
   },
+  "RDS_DISK_BURST_BALANCE_LOW_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "RDS_CREATE_SWAP_ALARM": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "RDS_HIGH_SWAP_USAGE_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   },
   "RDS_CREATE_ANOMALY_ALARM": {
     "required": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -136,10 +136,28 @@ variable "postgres_restore_snapshot_identifier" {
   default     = null
 }
 
+variable "rds_alarm_evaluation_period" {
+  type        = string
+  description = "The number of the most recent statistic periods, or data points, to evaluate when determining RDS alarm state."
+  default     = "5"
+}
+
+variable "rds_alarm_statistic_period" {
+  type        = string
+  description = "The length of time to use to evaluate the metric or expression to create each individual data point for an RDS alarm. It is expressed in seconds."
+  default     = "60"
+}
+
 variable "rds_create_high_cpu_alarm" {
   type        = bool
   description = "Whether or not to create a high CPU alarm for RDS."
   default     = true
+}
+
+variable "rds_max_cpu_utilization_threshold" {
+  type        = string
+  description = "The threshold for max CPU utilization for the database before the alarm gets triggered (if enabled)."
+  default     = "90"
 }
 
 variable "rds_create_high_queue_depth_alarm" {
@@ -148,10 +166,22 @@ variable "rds_create_high_queue_depth_alarm" {
   default     = true
 }
 
+variable "rds_disk_queue_depth_high_threshold" {
+  type        = string
+  description = "The threshold for the disk queue depth before the alarm gets triggered (if enabled)."
+  default     = "64"
+}
+
 variable "rds_create_low_disk_space_alarm" {
   type        = bool
   description = "Whether or not to create a low disk space alarm for RDS."
   default     = true
+}
+
+variable "rds_disk_free_storage_low_threshold" {
+  type        = string
+  description = "The threshold for the free disk storage space (in bytes) before the alarm gets triggered (if enabled)."
+  default     = "5368709120" // 5 GB
 }
 
 variable "rds_create_low_memory_alarm" {
@@ -160,10 +190,22 @@ variable "rds_create_low_memory_alarm" {
   default     = true
 }
 
+variable "rds_low_memory_threshold" {
+  type        = string
+  description = "The threshold for the low freeable memory (in bytes) before the alarm gets triggered (if enabled)."
+  default     = "256000000" // ~256 MB
+}
+
 variable "rds_create_low_cpu_credit_alarm" {
   type        = bool
   description = "Whether or not to create a low CPU credit alarm for RDS."
   default     = false
+}
+
+variable "rds_low_cpu_credit_balance_threshold" {
+  type        = string
+  description = "The threshold for the low CPU credit balance before the alarm gets triggered (if enabled)."
+  default     = "100"
 }
 
 variable "rds_create_low_disk_burst_alarm" {
@@ -172,10 +214,22 @@ variable "rds_create_low_disk_burst_alarm" {
   default     = false
 }
 
+variable "rds_disk_burst_balance_low_threshold" {
+  type        = string
+  description = "The threshold for the low disk burst balance before the alarm gets triggered (if enabled)."
+  default     = "100"
+}
+
 variable "rds_create_swap_alarm" {
   type        = bool
   description = "Whether or not to create a high swap usage alarm for RDS."
   default     = false
+}
+
+variable "rds_high_swap_usage_threshold" {
+  type        = string
+  description = "The threshold for the max swap usage before the alarm gets triggered (if enabled)."
+  default     = "256000000" // ~256 MB
 }
 
 variable "rds_create_anomaly_alarm" {

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -238,6 +238,12 @@ variable "rds_create_anomaly_alarm" {
   default     = false
 }
 
+variable "rds_max_used_transaction_ids_high_threshold" {
+  type        = string
+  description = "The threshold for the maximum transaction IDS before the alarm gets triggered. This is to prevent [transaciton ID wraparound](https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/)"
+  default     = "1000000000" // 1 billion. Half of total.
+}
+
 variable "aws_db_storage_type" {
   type        = string
   description = "(Optional) One of 'standard' (magnetic), 'gp2' (general purpose SSD), 'gp3' (general purpose SSD that needs iops independently) or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'gp2' if not."


### PR DESCRIPTION
Add additional configuration variables for AWS RDS alarms.

Related to: https://github.com/civiform/civiform/issues/5109