### PR TITLE
Use docker --format to parse snapshot from "latest" tag

### DIFF
--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -31,11 +31,13 @@ while getopts s:c:t: flag; do
 done
 
 # if the tag is "latest", resolve it to the specific snapshot tag from Docker
+# Go templating is used to parse the snapshot tag from the json returned by docker inspect
 if [[ "${tag}" == "latest" ]]; then
   docker pull --platform linux/x86_64 docker.io/civiform/civiform:latest
   snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest \
-    | grep 'CIVIFORM_IMAGE_TAG' \
-    | grep -oE 'SNAPSHOT-\w+-\d+')"
+    --format='{{range .Config.Env}}
+      {{if eq (printf "%.19s" .) "CIVIFORM_IMAGE_TAG="}}
+      {{slice . 19}}{{end}}{{end}}')"
   if [[ -z "${snapshot_tag}" ]]; then
     echo "Latest snapshot tag not found." 2>&1
     exit 1

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -34,10 +34,7 @@ done
 # Go templating is used to parse the snapshot tag from the json returned by docker inspect
 if [[ "${tag}" == "latest" ]]; then
   docker pull --platform linux/x86_64 docker.io/civiform/civiform:latest
-  snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest \
-    --format='{{range .Config.Env}}
-      {{if eq (printf "%.19s" .) "CIVIFORM_IMAGE_TAG="}}
-      {{slice . 19}}{{end}}{{end}}')"
+  snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest --format='{{range $i, $el := .Config.Env}}{{if eq (printf "%.19s" $el) "CIVIFORM_IMAGE_TAG="}}{{slice $el 19}}{{end}}{{end}}')"
   if [[ -z "${snapshot_tag}" ]]; then
     echo "Latest snapshot tag not found." 2>&1
     exit 1

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -32,12 +32,11 @@ done
 
 # if the tag is "latest", resolve it to the specific snapshot tag from Docker
 # Go templating is used to parse the snapshot tag from the json returned by docker inspect
+# https://docs.docker.com/engine/reference/commandline/inspect/#options
 if [[ "${tag}" == "latest" ]]; then
   docker pull --platform linux/x86_64 docker.io/civiform/civiform:latest
   snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest \
-    --format='{{range $i, $el := .Config.Env}}
-      {{if eq (printf "%.19s" $el) "CIVIFORM_IMAGE_TAG="}}
-      {{slice $el 19}}{{end}}{{end}}')"
+    --format='{{range .Config.Env}}{{if eq (printf "%.19s" .) "CIVIFORM_IMAGE_TAG="}}{{slice . 19}}{{end}}{{end}}')"
   if [[ -z "${snapshot_tag}" ]]; then
     echo "Latest snapshot tag not found." 2>&1
     exit 1

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -40,6 +40,7 @@ if [[ "${tag}" == "latest" ]]; then
     echo "Latest snapshot tag not found." 2>&1
     exit 1
   fi
+  echo "Resolved 'latest' to snapshot tag ${snapshot_tag}"
   tag="${snapshot_tag}"
 fi
 
@@ -71,6 +72,7 @@ else
     "['object']['url']")
   commit_sha=$(fetch_json_val ${tag_url} "['object']['sha']")
 fi
+echo "Fetched commit sha ${commit_sha}"
 
 dependencies_file_path="cloud/shared/bin/env-var-docs-python-dependencies.txt"
 

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -34,7 +34,10 @@ done
 # Go templating is used to parse the snapshot tag from the json returned by docker inspect
 if [[ "${tag}" == "latest" ]]; then
   docker pull --platform linux/x86_64 docker.io/civiform/civiform:latest
-  snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest --format='{{range $i, $el := .Config.Env}}{{if eq (printf "%.19s" $el) "CIVIFORM_IMAGE_TAG="}}{{slice $el 19}}{{end}}{{end}}')"
+  snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest \
+    --format='{{range $i, $el := .Config.Env}}
+      {{if eq (printf "%.19s" $el) "CIVIFORM_IMAGE_TAG="}}
+      {{slice $el 19}}{{end}}{{end}}')"
   if [[ -z "${snapshot_tag}" ]]; then
     echo "Latest snapshot tag not found." 2>&1
     exit 1


### PR DESCRIPTION
Currently, snapshot parsing is failing on staging due to different flag options for the `grep` command. This PR refactors the snapshot tag parsing to be done by [Docker's `--format` option](https://docs.docker.com/engine/reference/commandline/inspect/#options) + Go templating to make it system agnostic.

Also added a couple of log lines for help debugging.

I tested this locally and on staging and it works in both environments.