### PR TITLE
bump num tries before timeout

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -55,13 +55,13 @@ class AwsCli:
         Polls the CiviForm ECS service, waiting for the PRIMARY deployment to
         have rolloutStatus of COMPLETED.
 
-        Gives up after 30 tries, sleeps 30 seconds between each try.
+        Gives up after 60 tries, sleeps 30 seconds between each try.
         """
         print(
             "\nWaiting for CiviForm ECS service to become healthy.\n"
             f"Service URL: {self._get_url_of_ecs_service()}")
 
-        tries = 30
+        tries = 60
         while True:
             state = self._ecs_service_state()
             if state == "COMPLETED":


### PR DESCRIPTION
end 2 end tests have been failing for the past week: https://github.com/civiform/cloud-deploy-infra/actions/workflows/e2e-test.yaml

The error message is 
```ERROR: service did not become healthy in expected amount of time. This usually means the new tasks are crash-looping, but can mean the check timed out before the service finished starting.```

Doubling the number of status check tries before failure will let us know if it's a timeout issue or an actual failure and we need to dig deeper.

