### PR TITLE
Add APPLICANT_REGISTER_URI into e2e test config

### DIFF
--- a/e2e-test/civiform_config_aws_oidc.sh
+++ b/e2e-test/civiform_config_aws_oidc.sh
@@ -231,6 +231,11 @@ export APPLICANT_OIDC_PROVIDER_NAME="OidcClient"
 # Usually ends in .well-known/openid-configuration
 export APPLICANT_OIDC_DISCOVERY_URI="https://civiform-staging.us.auth0.com/.well-known/openid-configuration"
 
+# REQUIRED if CIVIFORM_APPLICANT_IDP="generic-oidc"
+# The URL applicants are redirected to for creating an account
+# with the identity provider.
+export APPLICANT_REGISTER_URI=""
+
 # OPTIONAL
 # The type of OIDC flow to execute, and how the data is encoded.
 # See https://auth0.com/docs/authenticate/protocols/oauth#authorization-endpoint


### PR DESCRIPTION
e2e tests are currently broken because `APPLICANT_REGISTER_URI` is missing from the config: https://github.com/civiform/cloud-deploy-infra/actions/runs/5652272897/job/15311631397