### PR TITLE
turn on server var autogeneration

### DIFF
--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -108,12 +108,12 @@ def _overwrite_checkout_file():
 
     # Replace args and command path name
     filedata = filedata.replace(
-        'args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")',
-        'args=("--command=${CMD_NAME}" "--tag=${CIVIFORM_VERSION}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")'
+        'args=("--command=${CMD_NAME}" "--tag=${CIVIFORM_VERSION}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")',
+        'args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")'
     )
     filedata = filedata.replace(
-        'CMD_NAME_PATH="cloud/shared/bin/run"',
-        'CMD_NAME_PATH="cloud/shared/bin/run.py"')
+        'CMD_NAME_PATH="cloud/shared/bin/run.py"',
+        'CMD_NAME_PATH="cloud/shared/bin/run"')
 
     # Write the file out again
     with open('../bin/lib/checkout.sh', 'w') as file:


### PR DESCRIPTION
Once [this pr](https://github.com/civiform/civiform/pull/5298) is merged, server var auto-generation will work on older versions of python which will unblock AR's use of it.