### PR TITLE
Make admin-writeable variables optional

### DIFF
--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -6,19 +6,19 @@
     "type": "string"
   },
   "CIVIC_ENTITY_FULL_NAME": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": true,
     "type": "string"
   },
   "CIVIC_ENTITY_SHORT_NAME": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": true,
     "type": "string"
   },
   "CIVIC_ENTITY_SUPPORT_EMAIL_ADDRESS": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": true,
     "type": "string"


### PR DESCRIPTION
These will be removed in a few weeks when we fully commit to server var autogeneration. In the meantime this allows them to be omitted in the config file.