### PR TITLE
No newline before CLI input

### DIFF
--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -90,7 +90,7 @@ def validate_tag(tag):
     print(
         f'''
         If you would like to continue deployment, please type YES below.
-        Continue: ''')
+        Continue: ''', end='', flush=True)
     resp = input()
     return resp.lower().strip() == 'yes'
 

--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -90,7 +90,9 @@ def validate_tag(tag):
     print(
         f'''
         If you would like to continue deployment, please type YES below.
-        Continue: ''', end='', flush=True)
+        Continue: ''',
+        end='',
+        flush=True)
     resp = input()
     return resp.lower().strip() == 'yes'
 


### PR DESCRIPTION
Fixes the CLI prompt for confirming a non-release tag to not print a newline before the user's input

Previous behavior:
<img width="710" alt="Screenshot 2023-08-07 at 3 21 14 PM" src="https://github.com/civiform/cloud-deploy-infra/assets/473671/1fcf3f20-cf66-4890-b217-ed74f067130d">
