### PR TITLE
Pin urllib3

### DIFF
--- a/cloud/shared/bin/env-var-docs-python-dependencies.txt
+++ b/cloud/shared/bin/env-var-docs-python-dependencies.txt
@@ -1,1 +1,4 @@
 requests==2.31.0
+# Need a 1.x version for AWS Cloudshell, as 2.0 requires compiling Python 
+# against OpenSSL 1.1.1+ and Cloudshell's python is compiled against 1.0.2k
+urllib3==1.26.16


### PR DESCRIPTION
This pins urllib3 to the latest 1.x version. When running on AWS Cloudshell, python is compiled against OpenSSL 1.0.2k, but urllib3 2.x requires it to be compiled against 1.1.1+. Because our code and dependencies work fine with 1.x (the actual dependency requirement is >=1.21.1), we pin it to this version for maximum compatibility.