### PR TITLE
Fix pgadmin bash

### DIFF
--- a/cloud/aws/pgadmin/build-pgdmin
+++ b/cloud/aws/pgadmin/build-pgdmin
@@ -2,8 +2,24 @@
 
 # Builds the customized pgadmin Docker image.
 
-docker build \
-  -t docker.io/civiform/pgadmin:latest \
-  -f pgadmin.Dockerfile .
+set -e
+set +x
 
-docker push docker.io/civiform/pgadmin:latest
+readonly SHORT_SHA="$(git rev-parse --short HEAD)"
+readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
+readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
+readonly IMAGE="pgadmin"
+
+PLATFORM_ARG=()
+if [[ -n "${PLATFORM}" ]]; then
+  PLATFORM_ARG=(--platform "${PLATFORM}")
+fi
+readonly PLATFORM_ARG
+
+echo "start ${IMAGE} build"
+docker buildx create --use
+docker buildx build --push \
+  "${PLATFORM_ARG[@]}" \
+  -t "docker.io/civiform/${IMAGE}:latest" \
+  -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
+  -f pgadmin.Dockerfile .

--- a/cloud/aws/pgadmin/build-pgdmin
+++ b/cloud/aws/pgadmin/build-pgdmin
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#! /usr/bin/env bash
 
 # Builds the customized pgadmin Docker image.
 


### PR DESCRIPTION
When trying to run this file, we'd get the error 

`./build-pgdmin: bad interpreter: /usr/bin/bash: no such file or directory`

Tested and this fixes it.