### PR TITLE
Enable execute for pgadmin ECS task

### DIFF
--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -79,6 +79,7 @@ resource "aws_ecs_service" "pgadmin" {
   task_definition = aws_ecs_task_definition.pgadmin.arn
   desired_count   = 1
   launch_type     = "FARGATE"
+  enable_execute_command  = true
   network_configuration {
     subnets = var.subnet_ids
     security_groups = [
@@ -146,6 +147,9 @@ resource "aws_iam_role" "civiform_pgadmin_task_execution_role" {
     }
 JSON
   tags               = local.tags
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  ]
 }
 resource "aws_iam_role_policy_attachment" "civiform_pgadmin_task_execution_role_policy_attach" {
   role       = aws_iam_role.civiform_pgadmin_task_execution_role.name

--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -74,12 +74,12 @@ resource "aws_security_group" "pgadmin_tasks" {
 
 # Run a pgadmin container via a ecs service.
 resource "aws_ecs_service" "pgadmin" {
-  name            = local.name_prefix
-  cluster         = var.ecs_cluster_arn
-  task_definition = aws_ecs_task_definition.pgadmin.arn
-  desired_count   = 1
-  launch_type     = "FARGATE"
-  enable_execute_command  = true
+  name                   = local.name_prefix
+  cluster                = var.ecs_cluster_arn
+  task_definition        = aws_ecs_task_definition.pgadmin.arn
+  desired_count          = 1
+  launch_type            = "FARGATE"
+  enable_execute_command = true
   network_configuration {
     subnets = var.subnet_ids
     security_groups = [

--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -147,6 +147,25 @@ resource "aws_iam_role" "civiform_pgadmin_task_execution_role" {
     }
 JSON
   tags               = local.tags
+}
+resource "aws_iam_role" "civiform_pgadmin_task_role" {
+  name               = "${local.name_prefix}-task-role"
+  assume_role_policy = <<JSON
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole",
+            "Sid": ""
+        }
+      ]
+    }
+JSON
+  tags               = local.tags
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   ]

--- a/cloud/aws/modules/pgadmin/task.tf
+++ b/cloud/aws/modules/pgadmin/task.tf
@@ -9,6 +9,7 @@ resource "aws_ecs_task_definition" "pgadmin" {
   ])
 
   execution_role_arn       = aws_iam_role.civiform_pgadmin_task_execution_role.arn
+  task_role_arn            = aws_iam_role.civiform_pgadmin_task_role.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
 


### PR DESCRIPTION
Enabling execute mode allows us to ssh into the pgadmin ECS task to run commands, such as pg_restore with more customized flags.

See [doc](https://docs.google.com/document/d/1sdkCUf3ViPmPmY0ltWrGOmlPJuY_HIaV4L2fxphPGoU/edit#heading=h.qwl4b729kpja) for more details on full pg restore steps that were used.

Related to https://github.com/civiform/civiform/issues/5447