### PR TITLE
Upgrade pgadmin version and hardcode platform

### DIFF
--- a/cloud/aws/pgadmin/build-pgdmin
+++ b/cloud/aws/pgadmin/build-pgdmin
@@ -9,42 +9,14 @@ readonly SHORT_SHA="$(git rev-parse --short HEAD)"
 readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
 readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
 readonly IMAGE="pgadmin"
-#readonly PLATFORM="linux/arm64"
-
-PLATFORM_ARG=()
-if [[ -n "${PLATFORM}" ]]; then
-  PLATFORM_ARG=(--platform "${PLATFORM}")
-fi
-readonly PLATFORM_ARG
+readonly PLATFORM=linux/amd64
 
 echo "start ${IMAGE} build"
 docker buildx create --use
 docker buildx build --push \
-  "${PLATFORM_ARG[@]}" \
+  --platform "${PLATFORM}" \
   -t "docker.io/civiform/${IMAGE}:latest" \
   -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
   -f pgadmin.Dockerfile .
-
-
-
-#docker build \
-#  -t docker.io/civiform/pgadmin:latest \
-#  -f pgadmin.Dockerfile .
-#
-#docker push docker.io/civiform/pgadmin:latest
-
-#if [[ ! -f "${1}" ]]; then
-#  echo "Usage: bin/dev-restore-db DUMP_FILE_NAME"
-#  exit 1
-#fi
-#
-## location of dump file in docker container
-#readonly DUMP_FILE="${1}"
-#
-#echo "copying file"
-#
-#docker ls
-#
-#docker cp ${DUMP_FILE} ${IMAGE}:/${DUMP_FILE}
 
 

--- a/cloud/aws/pgadmin/build-pgdmin
+++ b/cloud/aws/pgadmin/build-pgdmin
@@ -2,36 +2,36 @@
 
 # Builds the customized pgadmin Docker image.
 #
-#set -e
-#set +x
-#
-#readonly SHORT_SHA="$(git rev-parse --short HEAD)"
-#readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
-#readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
-#readonly IMAGE="pgadmin"
+set -e
+set +x
+
+readonly SHORT_SHA="$(git rev-parse --short HEAD)"
+readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
+readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
+readonly IMAGE="pgadmin"
 #readonly PLATFORM="linux/arm64"
-#
-#PLATFORM_ARG=()
-#if [[ -n "${PLATFORM}" ]]; then
-#  PLATFORM_ARG=(--platform "${PLATFORM}")
-#fi
-#readonly PLATFORM_ARG
-#
-#echo "start ${IMAGE} build"
-#docker buildx create --use
-#docker buildx build --push \
-#  "${PLATFORM_ARG[@]}" \
-#  -t "docker.io/civiform/${IMAGE}:latest" \
-#  -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
-#  -f pgadmin.Dockerfile .
-#
 
+PLATFORM_ARG=()
+if [[ -n "${PLATFORM}" ]]; then
+  PLATFORM_ARG=(--platform "${PLATFORM}")
+fi
+readonly PLATFORM_ARG
 
-docker build \
-  -t docker.io/civiform/pgadmin:latest \
+echo "start ${IMAGE} build"
+docker buildx create --use
+docker buildx build --push \
+  "${PLATFORM_ARG[@]}" \
+  -t "docker.io/civiform/${IMAGE}:latest" \
+  -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
   -f pgadmin.Dockerfile .
 
-docker push docker.io/civiform/pgadmin:latest
+
+
+#docker build \
+#  -t docker.io/civiform/pgadmin:latest \
+#  -f pgadmin.Dockerfile .
+#
+#docker push docker.io/civiform/pgadmin:latest
 
 #if [[ ! -f "${1}" ]]; then
 #  echo "Usage: bin/dev-restore-db DUMP_FILE_NAME"

--- a/cloud/aws/pgadmin/build-pgdmin
+++ b/cloud/aws/pgadmin/build-pgdmin
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # Builds the customized pgadmin Docker image.
-#
+
 set -e
 set +x
 

--- a/cloud/aws/pgadmin/build-pgdmin
+++ b/cloud/aws/pgadmin/build-pgdmin
@@ -1,25 +1,50 @@
 #! /usr/bin/env bash
 
 # Builds the customized pgadmin Docker image.
+#
+#set -e
+#set +x
+#
+#readonly SHORT_SHA="$(git rev-parse --short HEAD)"
+#readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
+#readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
+#readonly IMAGE="pgadmin"
+#readonly PLATFORM="linux/arm64"
+#
+#PLATFORM_ARG=()
+#if [[ -n "${PLATFORM}" ]]; then
+#  PLATFORM_ARG=(--platform "${PLATFORM}")
+#fi
+#readonly PLATFORM_ARG
+#
+#echo "start ${IMAGE} build"
+#docker buildx create --use
+#docker buildx build --push \
+#  "${PLATFORM_ARG[@]}" \
+#  -t "docker.io/civiform/${IMAGE}:latest" \
+#  -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
+#  -f pgadmin.Dockerfile .
+#
 
-set -e
-set +x
 
-readonly SHORT_SHA="$(git rev-parse --short HEAD)"
-readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
-readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
-readonly IMAGE="pgadmin"
-
-PLATFORM_ARG=()
-if [[ -n "${PLATFORM}" ]]; then
-  PLATFORM_ARG=(--platform "${PLATFORM}")
-fi
-readonly PLATFORM_ARG
-
-echo "start ${IMAGE} build"
-docker buildx create --use
-docker buildx build --push \
-  "${PLATFORM_ARG[@]}" \
-  -t "docker.io/civiform/${IMAGE}:latest" \
-  -t "docker.io/civiform/${IMAGE}:${SNAPSHOT_TAG}" \
+docker build \
+  -t docker.io/civiform/pgadmin:latest \
   -f pgadmin.Dockerfile .
+
+docker push docker.io/civiform/pgadmin:latest
+
+#if [[ ! -f "${1}" ]]; then
+#  echo "Usage: bin/dev-restore-db DUMP_FILE_NAME"
+#  exit 1
+#fi
+#
+## location of dump file in docker container
+#readonly DUMP_FILE="${1}"
+#
+#echo "copying file"
+#
+#docker ls
+#
+#docker cp ${DUMP_FILE} ${IMAGE}:/${DUMP_FILE}
+
+

--- a/cloud/aws/pgadmin/pgadmin.Dockerfile
+++ b/cloud/aws/pgadmin/pgadmin.Dockerfile
@@ -1,4 +1,4 @@
-FROM dpage/pgadmin4:6.15
+FROM dpage/pgadmin4:7.5
 
 USER root
 

--- a/cloud/aws/pgadmin/pgadmin.Dockerfile
+++ b/cloud/aws/pgadmin/pgadmin.Dockerfile
@@ -1,4 +1,4 @@
-FROM dpage/pgadmin4:6.19
+FROM dpage/pgadmin4:6.15
 
 USER root
 


### PR DESCRIPTION
I saw issues with pushing a docker image with a different platform, so hardcoding the platform helps us avoid  pushing the wrong platform version unexpectedly.

Also update to a newer version of pgadmin docker image

Related to https://github.com/civiform/civiform/issues/5447