### PR TITLE
Use Python 3.7 for testing

### DIFF
--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -21,6 +21,14 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v3
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+        
+      - name: Install requests
+        run: pip install requests
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,6 +17,14 @@ jobs:
     # https://docs.github.com/en/actions/using-jobs/using-concurrency
     concurrency: run-e2e-aws-oidc
     steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+        
+      - name: Install requests
+        run: pip install requests
+        
       - name: Checkout civiform/cloud-deploy-infra
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -15,7 +15,7 @@ jobs:
           - name: Set up Python
             uses: actions/setup-python@v4
             with:
-              python-version: '3.8'   
+              python-version: '3.7'   
           - name: Install dependencies
             run: |
               python -m pip install --upgrade pip


### PR DESCRIPTION
This sets up Python 3.7 to run tests against, since this is the minimum
version we support for the deploy system. This will help us ensure we
are not adding code that only works on >3.7.