### PR TITLE
Add new AWS secrets for admin OIDC

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -260,6 +260,8 @@ locals {
               aws_secretsmanager_secret.adfs_client_id_secret.arn,
               aws_secretsmanager_secret.applicant_oidc_client_secret_secret.arn,
               aws_secretsmanager_secret.applicant_oidc_client_id_secret.arn,
+              aws_secretsmanager_secret.admin_oidc_client_secret_secret.arn,
+              aws_secretsmanager_secret.admin_oidc_client_id_secret.arn,
             ]
           },
           {

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -70,7 +70,7 @@ module "civiform_server_container_def" {
     {
       name      = "APPLICANT_OIDC_CLIENT_SECRET"
       valueFrom = aws_secretsmanager_secret_version.applicant_oidc_client_secret_secret_version.arn
-    }
+    },
     {
       name      = "ADMIN_OIDC_CLIENT_ID"
       valueFrom = aws_secretsmanager_secret_version.admin_oidc_client_id_secret_version.arn

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -71,6 +71,14 @@ module "civiform_server_container_def" {
       name      = "APPLICANT_OIDC_CLIENT_SECRET"
       valueFrom = aws_secretsmanager_secret_version.applicant_oidc_client_secret_secret_version.arn
     }
+    {
+      name      = "ADMIN_OIDC_CLIENT_ID"
+      valueFrom = aws_secretsmanager_secret_version.admin_oidc_client_id_secret_version.arn
+    },
+    {
+      name      = "ADMIN_OIDC_CLIENT_SECRET"
+      valueFrom = aws_secretsmanager_secret_version.admin_oidc_client_secret_secret_version.arn
+    }
   ]
 
   map_environment = merge({

--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -13,6 +13,8 @@ ADFS_CLIENT_ID = 'civiform_adfs_client_id'
 ADFS_SECRET = 'civiform_adfs_secret'
 APPLICANT_OIDC_CLIENT_ID = 'civiform_applicant_oidc_client_id'
 APPLICANT_OIDC_CLIENT_SECRET = 'civiform_applicant_oidc_client_secret'
+ADMIN_OIDC_CLIENT_ID = 'civiform_admin_oidc_client_id'
+ADMIN_OIDC_CLIENT_SECRET = 'civiform_admin_oidc_client_secret'
 POSTGRES_PASSWORD = 'civiform_postgres_password'
 
 # Defined in cloud/aws/templates/aws_oidc/main.tf

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -32,7 +32,6 @@ class Setup(AwsSetupTemplate):
 
     def __init__(self, config: ConfigLoader):
         super().__init__(config)
-        print('XXX Creating Setup instance')
         self._aws_cli = AwsCli(config)
 
     def get_current_user(self) -> str:
@@ -58,14 +57,11 @@ class Setup(AwsSetupTemplate):
         return True
 
     def post_terraform_setup(self):
-        print('XXX post_terraform_setup start')
         if self.config.is_test():
             print(" - Test. Skipping post terraform setup.")
             return
 
-        print('XXX prompting for secrets')
         for name, doc in SECRETS.items():
-            print(f'XXX processing secret {name}')
             self._maybe_set_secret_value(
                 f'{self.config.app_prefix}-{name}', doc)
         self._maybe_change_default_db_password()

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -32,6 +32,7 @@ class Setup(AwsSetupTemplate):
 
     def __init__(self, config: ConfigLoader):
         super().__init__(config)
+        print('XXX Creating Setup instance')
         self._aws_cli = AwsCli(config)
 
     def get_current_user(self) -> str:
@@ -57,11 +58,14 @@ class Setup(AwsSetupTemplate):
         return True
 
     def post_terraform_setup(self):
+        print('XXX post_terraform_setup start')
         if self.config.is_test():
             print(" - Test. Skipping post terraform setup.")
             return
 
+        print('XXX prompting for secrets')
         for name, doc in SECRETS.items():
+            print(f'XXX processing secret {name}')
             self._maybe_set_secret_value(
                 f'{self.config.app_prefix}-{name}', doc)
         self._maybe_change_default_db_password()

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -18,9 +18,13 @@ SECRETS: Dict[str, str] = {
     resources.ADFS_SECRET:
         'Secret for the ADFS configuration. Enter any value if you do not use ADFS.',
     resources.APPLICANT_OIDC_CLIENT_ID:
-        'Client ID for your OIDC provider. Enter any value if you have not set it up yet.',
+        'Client ID for your OIDC provider for applicants. Enter any value if not applicable.',
     resources.APPLICANT_OIDC_CLIENT_SECRET:
-        'Client secret for your OIDC provider. Enter any value if you have not set it up yet.',
+        'Client secret for your OIDC provider for applicants. Enter any value if not applicable.',
+    resources.ADMIN_OIDC_CLIENT_ID:
+        'Client ID for your OIDC provider for admins. Enter any value if not applicable.',
+    resources.ADMIN_OIDC_CLIENT_SECRET:
+        'Client secret for your OIDC provider for admins. Enter any value if not applicable.',
 }
 
 

--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -183,27 +183,27 @@ resource "aws_secretsmanager_secret_version" "applicant_oidc_client_id_secret_ve
   secret_string = " "
 }
 
-# Creating a AWS secret for admin_oidc_secret
+# Creating an AWS secret for admin_oidc_secret
 resource "aws_secretsmanager_secret" "admin_oidc_client_secret_secret" {
   name                    = "${var.app_prefix}-civiform_admin_oidc_client_secret"
   kms_key_id              = aws_kms_key.civiform_kms_key.arn
   recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
-# Creating a AWS secret versions for admin_oidc_secret
+# Creating an AWS secret versions for admin_oidc_secret
 resource "aws_secretsmanager_secret_version" "admin_oidc_client_secret_secret_version" {
   secret_id     = aws_secretsmanager_secret.admin_oidc_client_secret_secret.id
   secret_string = " "
 }
 
-# Creating a AWS secret for admin_oidc_client_id
+# Creating an AWS secret for admin_oidc_client_id
 resource "aws_secretsmanager_secret" "admin_oidc_client_id_secret" {
   name                    = "${var.app_prefix}-civiform_admin_oidc_client_id"
   kms_key_id              = aws_kms_key.civiform_kms_key.arn
   recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
-# Creating a AWS secret versions for admin_oidc_client_id
+# Creating an AWS secret versions for admin_oidc_client_id
 resource "aws_secretsmanager_secret_version" "admin_oidc_client_id_secret_version" {
   secret_id     = aws_secretsmanager_secret.admin_oidc_client_id_secret.id
   secret_string = " "

--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -182,3 +182,29 @@ resource "aws_secretsmanager_secret_version" "applicant_oidc_client_id_secret_ve
   secret_id     = aws_secretsmanager_secret.applicant_oidc_client_id_secret.id
   secret_string = " "
 }
+
+# Creating a AWS secret for admin_oidc_secret
+resource "aws_secretsmanager_secret" "admin_oidc_client_secret_secret" {
+  name                    = "${var.app_prefix}-civiform_admin_oidc_client_secret"
+  kms_key_id              = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
+}
+
+# Creating a AWS secret versions for admin_oidc_secret
+resource "aws_secretsmanager_secret_version" "admin_oidc_client_secret_secret_version" {
+  secret_id     = aws_secretsmanager_secret.admin_oidc_client_secret_secret.id
+  secret_string = " "
+}
+
+# Creating a AWS secret for admin_oidc_client_id
+resource "aws_secretsmanager_secret" "admin_oidc_client_id_secret" {
+  name                    = "${var.app_prefix}-civiform_admin_oidc_client_id"
+  kms_key_id              = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
+}
+
+# Creating a AWS secret versions for admin_oidc_client_id
+resource "aws_secretsmanager_secret_version" "admin_oidc_client_id_secret_version" {
+  secret_id     = aws_secretsmanager_secret.admin_oidc_client_id_secret.id
+  secret_string = " "
+}


### PR DESCRIPTION
Add new AWS secrets for admin OIDC.

There is one new AWS secret for the admin OIDC client id and one new AWS secret for the admin OIDC client secret.

![AWS Secrets Manager screenshot showing new secrets](https://github.com/civiform/cloud-deploy-infra/assets/1391583/21daf712-ec9c-4f8d-9ba1-a5d7cf76fccc)
