### PR TITLE
Exit script when Terraform apply fails

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/aws_template.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_template.py
@@ -18,7 +18,7 @@ class AwsSetupTemplate(SetupTemplate):
             os.path.join(
                 self.config.get_template_dir(), 'setup',
                 self.config.tfvars_filename))
-        terraform.perform_apply(self.config, is_destroy, template_dir)
+        return terraform.perform_apply(self.config, is_destroy, template_dir)
 
     def setup_log_file(self):
         # TODO(#2606): If remote file exist fetch it here.

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -87,16 +87,7 @@ class Setup(AwsSetupTemplate):
 
     def pre_terraform_setup(self):
         print(' - Running the setup script in terraform')
-        self._tf_run_for_aws(is_destroy=False)
-
-    def should_retry_terraform_apply_once(self):
-        """
-        The initial terraform apply after the setup step fails due to
-        https://github.com/hashicorp/terraform-provider-aws/issues/19583.
-
-        Re-running terraform apply will succeed, however.
-        """
-        return True
+        return self._tf_run_for_aws(is_destroy=False)
 
     def requires_post_terraform_setup(self):
         return True

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -26,9 +26,6 @@ class Setup(SetupTemplate):
     def requires_post_terraform_setup(self):
         return True
 
-    def should_retry_terraform_apply_once(self):
-        return False
-
     def detect_backend_state_resources(self):
         # Not yet implemented, so assume
         # none of the resources exist yet.

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -58,18 +58,16 @@ def run(config: ConfigLoader, params: List[str]):
                 exit(1)
 
         print("Starting pre-terraform setup")
-        template_setup.pre_terraform_setup()
+        if not template_setup.pre_terraform_setup():
+            raise Exception("Setting up terraform backend resources failed")
 
         ###############################################################################
         # Terraform Init/Plan/Apply
         ###############################################################################
         print("Starting terraform deploy")
-        try:
-            terraform.perform_apply(config)
-        except subprocess.CalledProcessError:
-            if template_setup.should_retry_terraform_apply_once():
-                print("Initial terraform apply failed, retrying once:")
-                terraform.perform_apply(config)
+        deploy_succeeded = terraform.perform_apply(config)
+        if not deploy_succeeded:
+            raise Exception("Terraform apply failed")
 
         ###############################################################################
         # Post Run Setup Tasks (if needed)


### PR DESCRIPTION
This checks the result of perform_apply when running bin/setup so that it exits the script appropriately when it fails and doesn't attempt to do post-apply actions. If the apply fails for any reason (including a user entering "no" when asked if they want to do the apply), it exits with a non-zero code. Previously, the subprocess.check_call would have caught this and raised an exception. Now, since we wrap the call in a subprocess.Popen and simply return False if the exit code is non-zero, we have to handle this case differently.

Additionally, this removes the logic where we retry the apply if it fails. This bug in the Terraform aws provider was fixed in v5, which we are currently using.