### PR TITLE
Allow RDS performance insights and advanced monitoring to be enabled

### DIFF
--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -56,7 +56,6 @@ resource "aws_db_instance" "civiform" {
   performance_insights_enabled    = true
   monitoring_role_arn             = aws_iam_role.civiform_enhanced_monitoring_role.arn
   monitoring_interval             = 60
-  apply_immediately               = true
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -54,7 +54,7 @@ resource "aws_db_instance" "civiform" {
   storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   performance_insights_enabled    = var.rds_performance_insights_enabled
-  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role[count.index].arn : null
+  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role.arn : null
   monitoring_interval             = var.rds_enhanced_monitoring_enabled ? var.rds_enhanced_monitoring_interval : null
 }
 
@@ -68,7 +68,6 @@ data "aws_db_instance" "civiform" {
 
 # IAM Role for RDS Enhanced Monitoring
 resource "aws_iam_role" "civiform_enhanced_monitoring_role" {
-  count = var.rds_enhanced_monitoring_enabled ? 1 : 0
   name  = "civiform_enhanced_monitoring_role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -31,31 +31,30 @@ resource "aws_db_instance" "civiform" {
   }
 
   # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
-  snapshot_identifier               = var.postgres_restore_snapshot_identifier
-  deletion_protection               = local.deletion_protection
-  instance_class                    = var.postgres_instance_class
-  allocated_storage                 = var.postgres_storage_gb
-  max_allocated_storage             = var.postgres_max_allocated_storage_gb
-  storage_type                      = var.aws_db_storage_type
-  storage_throughput                = var.aws_db_storage_throughput
-  iops                              = var.aws_db_iops
-  engine                            = "postgres"
-  engine_version                    = "12"
-  username                          = aws_secretsmanager_secret_version.postgres_username_secret_version.secret_string
-  password                          = aws_secretsmanager_secret_version.postgres_password_secret_version.secret_string
-  vpc_security_group_ids            = [aws_security_group.rds.id]
-  db_subnet_group_name              = module.vpc.database_subnet_group_name
-  parameter_group_name              = aws_db_parameter_group.civiform.name
-  publicly_accessible               = false
-  skip_final_snapshot               = local.skip_final_snapshot
-  final_snapshot_identifier         = "${var.app_prefix}-civiform-db-finalsnapshot"
-  backup_retention_period           = var.postgres_backup_retention_days
-  kms_key_id                        = aws_kms_key.civiform_kms_key.arn
-  storage_encrypted                 = true
-  enabled_cloudwatch_logs_exports   = ["postgresql", "upgrade"]
-  performance_insights_enabled      = true
-  enhanced_monitoring_iam_role_arn  = aws_iam_role.civiform_enhanced_monitoring_role.arn
-  enhanced_monitoring_iam_role_name = aws_iam_role.civiform_enhanced_monitoring_role.name
+  snapshot_identifier             = var.postgres_restore_snapshot_identifier
+  deletion_protection             = local.deletion_protection
+  instance_class                  = var.postgres_instance_class
+  allocated_storage               = var.postgres_storage_gb
+  max_allocated_storage           = var.postgres_max_allocated_storage_gb
+  storage_type                    = var.aws_db_storage_type
+  storage_throughput              = var.aws_db_storage_throughput
+  iops                            = var.aws_db_iops
+  engine                          = "postgres"
+  engine_version                  = "12"
+  username                        = aws_secretsmanager_secret_version.postgres_username_secret_version.secret_string
+  password                        = aws_secretsmanager_secret_version.postgres_password_secret_version.secret_string
+  vpc_security_group_ids          = [aws_security_group.rds.id]
+  db_subnet_group_name            = module.vpc.database_subnet_group_name
+  parameter_group_name            = aws_db_parameter_group.civiform.name
+  publicly_accessible             = false
+  skip_final_snapshot             = local.skip_final_snapshot
+  final_snapshot_identifier       = "${var.app_prefix}-civiform-db-finalsnapshot"
+  backup_retention_period         = var.postgres_backup_retention_days
+  kms_key_id                      = aws_kms_key.civiform_kms_key.arn
+  storage_encrypted               = true
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  performance_insights_enabled    = true
+  monitoring_role_arn             = aws_iam_role.civiform_enhanced_monitoring_role.arn
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -56,6 +56,7 @@ resource "aws_db_instance" "civiform" {
   performance_insights_enabled    = true
   monitoring_role_arn             = aws_iam_role.civiform_enhanced_monitoring_role.arn
   monitoring_interval             = 60
+  apply_immediately               = true
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -53,6 +53,8 @@ resource "aws_db_instance" "civiform" {
   kms_key_id                      = aws_kms_key.civiform_kms_key.arn
   storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  performance_insights_enabled    = true
+  create_monitoring_role          = true
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -54,7 +54,7 @@ resource "aws_db_instance" "civiform" {
   storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   performance_insights_enabled    = var.rds_performance_insights_enabled
-  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role.arn : null
+  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role[count.index].arn : null
   monitoring_interval             = var.rds_enhanced_monitoring_enabled ? var.rds_enhanced_monitoring_interval : null
 }
 

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -54,7 +54,7 @@ resource "aws_db_instance" "civiform" {
   storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   performance_insights_enabled    = var.rds_performance_insights_enabled
-  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role.arn : null
+  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role[0].arn : null
   monitoring_interval             = var.rds_enhanced_monitoring_enabled ? var.rds_enhanced_monitoring_interval : null
 }
 
@@ -68,6 +68,7 @@ data "aws_db_instance" "civiform" {
 
 # IAM Role for RDS Enhanced Monitoring
 resource "aws_iam_role" "civiform_enhanced_monitoring_role" {
+  count = var.rds_enhanced_monitoring_enabled ? 1 : 0
   name  = "civiform_enhanced_monitoring_role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -54,7 +54,6 @@ resource "aws_db_instance" "civiform" {
   storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   performance_insights_enabled    = true
-  create_monitoring_role          = true
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -55,6 +55,7 @@ resource "aws_db_instance" "civiform" {
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   performance_insights_enabled    = true
   monitoring_role_arn             = aws_iam_role.civiform_enhanced_monitoring_role.arn
+  monitoring_interval             = 60
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -53,9 +53,9 @@ resource "aws_db_instance" "civiform" {
   kms_key_id                      = aws_kms_key.civiform_kms_key.arn
   storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
-  performance_insights_enabled    = true
-  monitoring_role_arn             = aws_iam_role.civiform_enhanced_monitoring_role.arn
-  monitoring_interval             = 60
+  performance_insights_enabled    = var.rds_performance_insights_enabled
+  monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role.arn : null
+  monitoring_interval             = var.rds_enhanced_monitoring_enabled ? var.rds_enhanced_monitoring_interval : null
 }
 
 # Provide database information for other resources (pgadmin, for example).
@@ -68,8 +68,8 @@ data "aws_db_instance" "civiform" {
 
 # IAM Role for RDS Enhanced Monitoring
 resource "aws_iam_role" "civiform_enhanced_monitoring_role" {
-
-  name = "civiform_enhanced_monitoring_role"
+  count = var.rds_enhanced_monitoring_enabled ? 1 : 0
+  name  = "civiform_enhanced_monitoring_role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -170,7 +170,8 @@
       "db.m4.2xlarge",
       "db.m5.large",
       "db.m5.xlarge",
-      "db.m5.2xlarge"
+      "db.m5.2xlarge",
+      "db.m6g.large"
     ]
   },
   "POSTGRES_STORAGE_GB": {

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -198,6 +198,24 @@
     "tfvar": true,
     "type": "string"
   },
+  "RDS_PERFORMANCE_INSIGHTS_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "RDS_ENHANCED_MONITORING_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "RDS_ENHANCED_MONITORING_INTERVAL": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
   "RDS_ALARM_EVALUATION_PERIOD": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -136,6 +136,24 @@ variable "postgres_restore_snapshot_identifier" {
   default     = null
 }
 
+variable "rds_performance_insights_enabled" {
+  type        = bool
+  description = "Whether or not to enable RDS performance insights for debugging purposes. Note: this may incur charges within AWS."
+  default     = false
+}
+
+variable "rds_enhanced_monitoring_enabled" {
+  type        = bool
+  description = "Whether or not to enable RDS enhanced monitoring for debugging purposes. Note: this may incur charges within AWS."
+  default     = false
+}
+
+variable "rds_enhanced_monitoring_interval" {
+  type        = number
+  description = "The monitoring interval to use for enhanced monitoring, if it is enabled."
+  default     = 60
+}
+
 variable "rds_alarm_evaluation_period" {
   type        = string
   description = "The number of the most recent statistic periods, or data points, to evaluate when determining RDS alarm state."


### PR DESCRIPTION
This allows these advanced database monitoring tools to be enabled through terraform.

By default they will be turned off.

https://github.com/civiform/civiform/issues/5605