### PR TITLE
Document that the no index meta tag is false by default

### DIFF
--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -612,7 +612,7 @@ variable "show_civiform_image_tag_on_landing_page" {
 }
 variable "staging_add_noindex_meta_tag" {
   type        = bool
-  description = "Whether to add a robots=noindex meta tag, which causes search engines to not list the website."
+  description = "Whether to add a robots=noindex meta tag, which causes search engines to not list the website. This defaults to false, meaning sites will appear on search."
   default     = false
 }
 variable "staging_disable_demo_mode_logins" {


### PR DESCRIPTION
Update the env var docs to document the default state for STAGING_ADD_NOINDEX_META_TAG

Related to https://github.com/civiform/civiform/issues/5635