### PR TITLE
add high memory utilization alarm

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/outputs.tf
+++ b/cloud/aws/modules/ecs_fargate_service/outputs.tf
@@ -11,3 +11,8 @@ output "aws_security_group_lb_access_sg_id" {
   description = "The ID of the security group"
   value       = aws_security_group.lb_access_sg.id
 }
+
+output "aws_ecs_service_name" {
+  description = "The service name of the aws ecs service."
+  value       = aws_ecs_service.service.name
+}

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -195,7 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   count               = var.ecs_create_high_memory_alarm ? 1 : 0
-  alarm_name          = "ecs-${module.ecs_cluster.name}-highMemoryUtilization"
+  alarm_name          = "ecs-${module.ecs_cluster.aws_ecs_cluster_cluster_name}-highMemoryUtilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.ecs_alarm_evaluation_period
   metric_name         = "MemoryUtilization"
@@ -207,6 +207,6 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
-    ClusterName = module.ecs_cluster.name
+    ClusterName = module.ecs_cluster.aws_ecs_cluster_cluster_name
   }
 }

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -34,6 +34,24 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
+  count               = var.rds_create_high_memory_alarm ? 1 : 0
+  alarm_name          = "rds-${data.aws_db_instance.civiform.id}-highMemoryUtilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.rds_alarm_evaluation_period
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/RDS"
+  period              = var.rds_alarm_statistic_period
+  statistic           = "Average"
+  threshold           = var.rds_max_memory_utilization_threshold
+  alarm_description   = "Average database memory utilization is too high."
+  alarm_actions       = local.rds_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = data.aws_db_instance.civiform.id
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   count               = var.rds_create_low_cpu_credit_alarm ? length(regexall("(t2|t3|t4)", var.postgres_instance_class)) > 0 ? 1 : 0 : 0
   alarm_name          = "rds-${data.aws_db_instance.civiform.id}-lowCPUCreditBalance"

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -1,18 +1,18 @@
 // SNS topic to alert if an alarm gets triggered
 resource "aws_sns_topic" "civiform_alert_topic" {
-  count = var.rds_alarm_email != "" ? 1 : 0
+  count = var.civiform_alarm_email != "" ? 1 : 0
   name  = "${var.app_prefix}-civiform-alert-topic"
 }
 
 resource "aws_sns_topic_subscription" "civiform_alert_subscription" {
-  count     = var.rds_alarm_email != "" ? 1 : 0
+  count     = var.civiform_alarm_email != "" ? 1 : 0
   topic_arn = aws_sns_topic.civiform_alert_topic[0].arn
   protocol  = "email"
-  endpoint  = var.rds_alarm_email
+  endpoint  = var.civiform_alarm_email
 }
 
 locals {
-  rds_alarm_actions = var.rds_alarm_email != "" ? [aws_sns_topic.civiform_alert_topic[0].arn] : []
+  civiform_alarm_actions = var.civiform_alarm_email != "" ? [aws_sns_topic.civiform_alert_topic[0].arn] : []
 }
 
 // CPU Utilization
@@ -27,26 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   statistic           = "Average"
   threshold           = var.rds_max_cpu_utilization_threshold
   alarm_description   = "Average database CPU utilization is too high."
-  alarm_actions       = local.rds_alarm_actions
-
-  dimensions = {
-    DBInstanceIdentifier = data.aws_db_instance.civiform.id
-  }
-}
-
-// Memory Utilization
-resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
-  count               = var.rds_create_high_memory_alarm ? 1 : 0
-  alarm_name          = "rds-${data.aws_db_instance.civiform.id}-highMemoryUtilization"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = var.rds_alarm_evaluation_period
-  metric_name         = "MemoryUtilization"
-  namespace           = "AWS/RDS"
-  period              = var.rds_alarm_statistic_period
-  statistic           = "Average"
-  threshold           = var.rds_max_memory_utilization_threshold
-  alarm_description   = "Average database memory utilization is too high."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -64,7 +45,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   statistic           = "Average"
   threshold           = var.rds_low_cpu_credit_balance_threshold
   alarm_description   = "Average database CPU credit balance is too low, a negative performance impact is imminent. When this alarm triggers, the database [instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) should be increased."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -83,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   statistic           = "Average"
   threshold           = var.rds_disk_queue_depth_high_threshold
   alarm_description   = "Average database disk queue depth is too high, performance may be negatively impacted."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -101,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_free_storage_space_too_low" {
   statistic           = "Average"
   threshold           = var.rds_disk_free_storage_low_threshold
   alarm_description   = "Average database free storage space is too low and may fill up soon."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -119,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_burst_balance_too_low" {
   statistic           = "Average"
   threshold           = var.rds_disk_burst_balance_low_threshold
   alarm_description   = "Average database storage burst balance is too low, a negative performance impact is imminent."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -138,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_freeable_too_low" {
   statistic           = "Average"
   threshold           = var.rds_low_memory_threshold
   alarm_description   = "Average database freeable memory is too low, performance may be negatively impacted."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -156,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
   statistic           = "Average"
   threshold           = var.rds_high_swap_usage_threshold
   alarm_description   = "Average database swap usage is too high, performance may be negatively impacted."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
     DBInstanceIdentifier = data.aws_db_instance.civiform.id
@@ -171,7 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
   evaluation_periods  = var.rds_alarm_evaluation_period
   threshold_metric_id = "e1"
   alarm_description   = "Anomalous database connection count detected. Check the monitoring graphs and logs for any suspicious activity."
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
 
   metric_query {
     id          = "e1"
@@ -209,5 +190,23 @@ resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
   statistic           = "Average"
   threshold           = var.rds_max_used_transaction_ids_high_threshold
   alarm_description   = "Nearing a possible critical transaction ID wraparound. More info [here](https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/)"
-  alarm_actions       = local.rds_alarm_actions
+  alarm_actions       = local.civiform_alarm_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
+  count               = var.ecs_create_high_memory_alarm ? 1 : 0
+  alarm_name          = "ecs-${module.ecs_cluster.cluster_id}-highMemoryUtilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.ecs_alarm_evaluation_period
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = var.ecs_alarm_statistic_period
+  statistic           = "Average"
+  threshold           = var.ecs_max_memory_utilization_threshold
+  alarm_description   = "Average ECS service memory utilization is too high."
+  alarm_actions       = local.civiform_alarm_actions
+
+  dimensions = {
+    ClusterName = module.ecs_cluster.cluster_id
+  }
 }

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -208,6 +208,6 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
 
   dimensions = {
     ClusterName = module.ecs_cluster.aws_ecs_cluster_cluster_name
-    ServiceName = "${module.ecs_cluster.aws_ecs_cluster_cluster_name}-service"
+    ServiceName = aws_ecs_service.service.name
   }
 }

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -207,6 +207,6 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   alarm_actions       = local.civiform_alarm_actions
 
   dimensions = {
-    ClusterName = module.ecs_cluster.cluster_id
+    ClusterName = module.ecs_cluster.name
   }
 }

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -13,6 +13,7 @@ resource "aws_sns_topic_subscription" "civiform_alert_subscription" {
 
 locals {
   civiform_alarm_actions = var.civiform_alarm_email != "" ? [aws_sns_topic.civiform_alert_topic[0].arn] : []
+
 }
 
 // CPU Utilization
@@ -193,9 +194,13 @@ resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
   alarm_actions       = local.civiform_alarm_actions
 }
 
+locals {
+  name_prefix = "${module.ecs_cluster.aws_ecs_cluster_cluster_name}-${module.ecs_fargate_service.aws_ecs_service_name}"
+}
+
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   count               = var.ecs_create_high_memory_alarm ? 1 : 0
-  alarm_name          = "ecs-${module.ecs_cluster.aws_ecs_cluster_cluster_name}-highMemoryUtilization"
+  alarm_name          = "${local.name_prefix}-highMemoryUtilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.ecs_alarm_evaluation_period
   metric_name         = "MemoryUtilization"
@@ -208,6 +213,6 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
 
   dimensions = {
     ClusterName = module.ecs_cluster.aws_ecs_cluster_cluster_name
-    ServiceName = aws_ecs_service.service.name
+    ServiceName = module.ecs_fargate_service.aws_ecs_service_name
   }
 }

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -34,6 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   }
 }
 
+// Memory Utilization
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   count               = var.rds_create_high_memory_alarm ? 1 : 0
   alarm_name          = "rds-${data.aws_db_instance.civiform.id}-highMemoryUtilization"

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -195,7 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   count               = var.ecs_create_high_memory_alarm ? 1 : 0
-  alarm_name          = "ecs-${module.ecs_cluster.cluster_id}-highMemoryUtilization"
+  alarm_name          = "ecs-${module.ecs_cluster.name}-highMemoryUtilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.ecs_alarm_evaluation_period
   metric_name         = "MemoryUtilization"

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -194,10 +194,6 @@ resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
   alarm_actions       = local.civiform_alarm_actions
 }
 
-locals {
-  name_prefix = "${module.ecs_cluster.aws_ecs_cluster_cluster_name}-${module.ecs_fargate_service.aws_ecs_service_name}"
-}
-
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   count               = var.ecs_create_high_memory_alarm ? 1 : 0
   alarm_name          = "${local.name_prefix}-highMemoryUtilization"

--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -208,5 +208,6 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
 
   dimensions = {
     ClusterName = module.ecs_cluster.aws_ecs_cluster_cluster_name
+    ServiceName = "${module.ecs_cluster.aws_ecs_cluster_cluster_name}-service"
   }
 }

--- a/cloud/aws/templates/aws_oidc/modules.tf
+++ b/cloud/aws/templates/aws_oidc/modules.tf
@@ -1,3 +1,0 @@
-module "ecs_fargate_service" {
-  source = "./../../modules/ecs_fargate_service"
-}

--- a/cloud/aws/templates/aws_oidc/modules.tf
+++ b/cloud/aws/templates/aws_oidc/modules.tf
@@ -1,0 +1,3 @@
+module "ecs_fargate_service" {
+  source = "./../../modules/ecs_fargate_service"
+}

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -248,6 +248,18 @@
     "tfvar": true,
     "type": "string"
   },
+  "RDS_CREATE_HIGH_MEMORY_ALARM": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "RDS_MAX_MEMORY_UTILIZATION_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "RDS_CREATE_HIGH_QUEUE_DEPTH_ALARM": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -230,7 +230,7 @@
     "tfvar": true,
     "type": "string"
   },
-  "RDS_ALARM_EMAIL": {
+  "CIVIFORM_ALARM_EMAIL": {
     "required": false,
     "secret": false,
     "tfvar": true,
@@ -243,18 +243,6 @@
     "type": "bool"
   },
   "RDS_MAX_CPU_UTILIZATION_THRESHOLD": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "string"
-  },
-  "RDS_CREATE_HIGH_MEMORY_ALARM": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "bool"
-  },
-  "RDS_MAX_MEMORY_UTILIZATION_THRESHOLD": {
     "required": false,
     "secret": false,
     "tfvar": true,
@@ -386,12 +374,6 @@
     "tfvar": true,
     "type": "integer"
   },
-  "ECS_TASK_MEMORY": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "integer"
-  },
   "ECS_MAX_CPU_THRESHOLD": {
     "required": false,
     "secret": false,
@@ -423,6 +405,36 @@
     "type": "string"
   },
   "ECS_MIN_CPU_PERIOD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "ECS_TASK_MEMORY": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
+  "ECS_CREATE_HIGH_MEMORY_ALARM": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
+  "ECS_MAX_MEMORY_UTILIZATION_THRESHOLD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "ECS_ALARM_EVALUATION_PERIOD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "ECS_ALARM_STATISTIC_PERIOD": {
     "required": false,
     "secret": false,
     "tfvar": true,

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -374,6 +374,12 @@
     "tfvar": true,
     "type": "integer"
   },
+  "ECS_TASK_MEMORY": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
   "ECS_MAX_CPU_THRESHOLD": {
     "required": false,
     "secret": false,
@@ -409,12 +415,6 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
-  },
-  "ECS_TASK_MEMORY": {
-    "required": false,
-    "secret": false,
-    "tfvar": true,
-    "type": "integer"
   },
   "ECS_CREATE_HIGH_MEMORY_ALARM": {
     "required": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -184,6 +184,18 @@ variable "rds_max_cpu_utilization_threshold" {
   default     = "90"
 }
 
+variable "rds_create_high_memory_alarm" {
+  type        = bool
+  description = "Whether or not to create a high memory alarm for RDS."
+  default     = true
+}
+
+variable "rds_max_memory_utilization_threshold" {
+  type        = string
+  description = "The threshold for max memory utilization for the database before the alarm gets triggered (if enabled)."
+  default     = "80"
+}
+
 variable "rds_create_high_queue_depth_alarm" {
   type        = bool
   description = "Whether or not to create a high queue depth alarm for RDS."

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -505,6 +505,12 @@ variable "ecs_task_cpu" {
   default     = 1024
 }
 
+variable "ecs_task_memory" {
+  type        = number
+  description = "Memory of each ECS task. See [these docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size) for potential values. If you change this variable, you may need to change the `ecs_task_cpu` as well."
+  default     = 6144
+}
+
 variable "ecs_max_cpu_threshold" {
   type        = string
   description = "The threshold for max CPU usage in an ECS task. If the CPU increases above this threshold, there will be a cloudwatch alarm and another ECS task will be added."
@@ -539,12 +545,6 @@ variable "ecs_min_cpu_period" {
   type        = string
   description = "The period in seconds over which the specified statistic is applied for min cpu metric alarm."
   default     = "60"
-}
-
-variable "ecs_task_memory" {
-  type        = number
-  description = "Memory of each ECS task. See [these docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size) for potential values. If you change this variable, you may need to change the `ecs_task_cpu` as well."
-  default     = 6144
 }
 
 variable "ecs_create_high_memory_alarm" {

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -154,9 +154,9 @@ variable "rds_enhanced_monitoring_interval" {
   default     = 60
 }
 
-variable "rds_alarm_email" {
+variable "civiform_alarm_email" {
   type        = string
-  description = "The address to notify when any enabled RDS alarm alerts. If unset, no emails will be sent."
+  description = "The address to notify when any enabled civiform alarm alerts. If unset, no emails will be sent."
   default     = ""
 }
 
@@ -182,18 +182,6 @@ variable "rds_max_cpu_utilization_threshold" {
   type        = string
   description = "The threshold for max CPU utilization for the database before the alarm gets triggered (if enabled)."
   default     = "90"
-}
-
-variable "rds_create_high_memory_alarm" {
-  type        = bool
-  description = "Whether or not to create a high memory alarm for RDS."
-  default     = true
-}
-
-variable "rds_max_memory_utilization_threshold" {
-  type        = string
-  description = "The threshold for max memory utilization for the database before the alarm gets triggered (if enabled)."
-  default     = "80"
 }
 
 variable "rds_create_high_queue_depth_alarm" {
@@ -517,12 +505,6 @@ variable "ecs_task_cpu" {
   default     = 1024
 }
 
-variable "ecs_task_memory" {
-  type        = number
-  description = "Memory of each ECS task. See [these docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size) for potential values. If you change this variable, you may need to change the `ecs_task_cpu` as well."
-  default     = 6144
-}
-
 variable "ecs_max_cpu_threshold" {
   type        = string
   description = "The threshold for max CPU usage in an ECS task. If the CPU increases above this threshold, there will be a cloudwatch alarm and another ECS task will be added."
@@ -556,6 +538,36 @@ variable "ecs_max_cpu_period" {
 variable "ecs_min_cpu_period" {
   type        = string
   description = "The period in seconds over which the specified statistic is applied for min cpu metric alarm."
+  default     = "60"
+}
+
+variable "ecs_task_memory" {
+  type        = number
+  description = "Memory of each ECS task. See [these docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size) for potential values. If you change this variable, you may need to change the `ecs_task_cpu` as well."
+  default     = 6144
+}
+
+variable "ecs_create_high_memory_alarm" {
+  type        = bool
+  description = "Whether or not to create a high memory alarm for ECS."
+  default     = true
+}
+
+variable "ecs_max_memory_utilization_threshold" {
+  type        = string
+  description = "The threshold for max memory utilization for ECS before the alarm gets triggered (if enabled)."
+  default     = "80"
+}
+
+variable "ecs_alarm_evaluation_period" {
+  type        = string
+  description = "The number of the most recent statistic periods, or data points, to evaluate when determining RDS alarm state."
+  default     = "5"
+}
+
+variable "ecs_alarm_statistic_period" {
+  type        = string
+  description = "The length of time to use to evaluate the metric or expression to create each individual data point for an RDS alarm. It is expressed in seconds."
   default     = "60"
 }
 

--- a/cloud/shared/bin/lib/terraform.py
+++ b/cloud/shared/bin/lib/terraform.py
@@ -145,8 +145,8 @@ def perform_apply(
         if "Error acquiring the state lock" in output:
             # Lock ID is a standard UUID v4 in the form 00000000-0000-0000-0000-000000000000
             match = re.search(
-                    r'ID:\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
-                    output)
+                r'ID:\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
+                output)
             error_text = inspect.cleandoc(
                 """
                 The Terraform state lock can not be acquired.


### PR DESCRIPTION
Add an alarm to check if the MemoryUtilization metric is above a threshold (default 80%).

[Cloudwatch metrics](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html)

![Tested on local deployment](https://github.com/civiform/cloud-deploy-infra/assets/6694735/340c10f5-aa91-4e6b-9f91-846894d06133)
