### PR TITLE
Add variable to disable monitoring stack

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -350,10 +350,11 @@ resource "aws_ecs_task_definition" "td" {
   cpu    = var.ecs_task_cpu
   memory = var.ecs_task_memory
 
-  container_definitions = jsonencode([
-    module.civiform_server_container_def.json_map_object,
-    module.civiform_metrics_scraper_container_def.json_map_object
-  ])
+  container_definitions = jsonencode(
+    var.monitoring_stack_enabled
+    ? [module.civiform_server_container_def.json_map_object,
+    module.civiform_metrics_scraper_container_def.json_map_object]
+  : [module.civiform_server_container_def.json_map_object])
 
   task_role_arn            = aws_iam_role.civiform_ecs_task_execution_role.arn
   execution_role_arn       = aws_iam_role.civiform_ecs_task_execution_role.arn

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -350,8 +350,10 @@ resource "aws_ecs_task_definition" "td" {
   cpu    = var.ecs_task_cpu
   memory = var.ecs_task_memory
 
-  container_definitions = jsonencode([module.civiform_server_container_def.json_map_object,
-  module.civiform_metrics_scraper_container_def.json_map_object])
+  container_definitions = jsonencode([
+    module.civiform_server_container_def.json_map_object,
+    module.civiform_metrics_scraper_container_def.json_map_object
+  ])
 
   task_role_arn            = aws_iam_role.civiform_ecs_task_execution_role.arn
   execution_role_arn       = aws_iam_role.civiform_ecs_task_execution_role.arn

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -211,7 +211,7 @@ module "civiform_metrics_scraper_container_def" {
   container_memory_reservation = 1024
 
   map_environment = {
-    PROMETHEUS_WRITE_ENDPOINT = "${aws_prometheus_workspace.metrics[0].prometheus_endpoint}api/v1/remote_write"
+    PROMETHEUS_WRITE_ENDPOINT = var.monitoring_stack_enabled ? "${aws_prometheus_workspace.metrics[0].prometheus_endpoint}api/v1/remote_write" : ""
     AWS_REGION                = var.aws_region
   }
 

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -211,7 +211,7 @@ module "civiform_metrics_scraper_container_def" {
   container_memory_reservation = 1024
 
   map_environment = {
-    PROMETHEUS_WRITE_ENDPOINT = "${aws_prometheus_workspace.metrics.prometheus_endpoint}api/v1/remote_write"
+    PROMETHEUS_WRITE_ENDPOINT = "${aws_prometheus_workspace.metrics[0].prometheus_endpoint}api/v1/remote_write"
     AWS_REGION                = var.aws_region
   }
 

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -350,11 +350,8 @@ resource "aws_ecs_task_definition" "td" {
   cpu    = var.ecs_task_cpu
   memory = var.ecs_task_memory
 
-  container_definitions = jsonencode(
-    var.monitoring_stack_enabled
-    ? [module.civiform_server_container_def.json_map_object,
-    module.civiform_metrics_scraper_container_def.json_map_object]
-  : [module.civiform_server_container_def.json_map_object])
+  container_definitions = jsonencode([module.civiform_server_container_def.json_map_object,
+  module.civiform_metrics_scraper_container_def.json_map_object])
 
   task_role_arn            = aws_iam_role.civiform_ecs_task_execution_role.arn
   execution_role_arn       = aws_iam_role.civiform_ecs_task_execution_role.arn

--- a/cloud/aws/templates/aws_oidc/monitoring.tf
+++ b/cloud/aws/templates/aws_oidc/monitoring.tf
@@ -1,12 +1,15 @@
 resource "aws_prometheus_workspace" "metrics" {
+  count = var.monitoring_stack_enabled ? 1 : 0
   alias = "${var.app_prefix}-CiviForm_metrics"
 }
 
 resource "random_id" "grafana_workspace_id" {
+  count = var.monitoring_stack_enabled ? 1 : 0
   byte_length = 1
 }
 
 resource "aws_grafana_workspace" "CiviForm_metrics" {
+  count = var.monitoring_stack_enabled ? 1 : 0
   name                     = "${var.app_prefix}-civiform-metrics"
   description              = "Grafana instance for ${var.app_prefix}-civiform-metrics-${random_id.grafana_workspace_id.dec}"
   data_sources             = ["PROMETHEUS"]
@@ -17,6 +20,7 @@ resource "aws_grafana_workspace" "CiviForm_metrics" {
 }
 
 resource "aws_iam_role" "grafana_assume_role" {
+  count = var.monitoring_stack_enabled ? 1 : 0
   name = "${var.app_prefix}-grafana-assume-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -34,6 +38,7 @@ resource "aws_iam_role" "grafana_assume_role" {
 }
 
 resource "aws_iam_policy" "civiform_monitoring_role_policy" {
+  count = var.monitoring_stack_enabled ? 1 : 0
   name = "${var.app_prefix}-civiform-monitoring-role-policy"
   policy = jsonencode(
     {
@@ -90,6 +95,7 @@ resource "aws_iam_policy" "civiform_monitoring_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "civiform_monitoring_role_policies_attach" {
+  count = var.monitoring_stack_enabled ? 1 : 0
   role       = aws_iam_role.grafana_assume_role.name
   policy_arn = aws_iam_policy.civiform_monitoring_role_policy.arn
 }

--- a/cloud/aws/templates/aws_oidc/monitoring.tf
+++ b/cloud/aws/templates/aws_oidc/monitoring.tf
@@ -19,7 +19,7 @@ resource "aws_grafana_workspace" "CiviForm_metrics" {
 }
 
 resource "aws_iam_role" "grafana_assume_role" {
-  name  = "${var.app_prefix}-grafana-assume-role"
+  name = "${var.app_prefix}-grafana-assume-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -36,7 +36,7 @@ resource "aws_iam_role" "grafana_assume_role" {
 }
 
 resource "aws_iam_policy" "civiform_monitoring_role_policy" {
-  name  = "${var.app_prefix}-civiform-monitoring-role-policy"
+  name = "${var.app_prefix}-civiform-monitoring-role-policy"
   policy = jsonencode(
     {
       "Version" : "2012-10-17",

--- a/cloud/aws/templates/aws_oidc/monitoring.tf
+++ b/cloud/aws/templates/aws_oidc/monitoring.tf
@@ -4,7 +4,6 @@ resource "aws_prometheus_workspace" "metrics" {
 }
 
 resource "random_id" "grafana_workspace_id" {
-  count       = var.monitoring_stack_enabled ? 1 : 0
   byte_length = 1
 }
 
@@ -20,7 +19,6 @@ resource "aws_grafana_workspace" "CiviForm_metrics" {
 }
 
 resource "aws_iam_role" "grafana_assume_role" {
-  count = var.monitoring_stack_enabled ? 1 : 0
   name  = "${var.app_prefix}-grafana-assume-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -38,7 +36,6 @@ resource "aws_iam_role" "grafana_assume_role" {
 }
 
 resource "aws_iam_policy" "civiform_monitoring_role_policy" {
-  count = var.monitoring_stack_enabled ? 1 : 0
   name  = "${var.app_prefix}-civiform-monitoring-role-policy"
   policy = jsonencode(
     {
@@ -95,7 +92,6 @@ resource "aws_iam_policy" "civiform_monitoring_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "civiform_monitoring_role_policies_attach" {
-  count      = var.monitoring_stack_enabled ? 1 : 0
   role       = aws_iam_role.grafana_assume_role.name
   policy_arn = aws_iam_policy.civiform_monitoring_role_policy.arn
 }

--- a/cloud/aws/templates/aws_oidc/monitoring.tf
+++ b/cloud/aws/templates/aws_oidc/monitoring.tf
@@ -4,12 +4,12 @@ resource "aws_prometheus_workspace" "metrics" {
 }
 
 resource "random_id" "grafana_workspace_id" {
-  count = var.monitoring_stack_enabled ? 1 : 0
+  count       = var.monitoring_stack_enabled ? 1 : 0
   byte_length = 1
 }
 
 resource "aws_grafana_workspace" "CiviForm_metrics" {
-  count = var.monitoring_stack_enabled ? 1 : 0
+  count                    = var.monitoring_stack_enabled ? 1 : 0
   name                     = "${var.app_prefix}-civiform-metrics"
   description              = "Grafana instance for ${var.app_prefix}-civiform-metrics-${random_id.grafana_workspace_id.dec}"
   data_sources             = ["PROMETHEUS"]
@@ -21,7 +21,7 @@ resource "aws_grafana_workspace" "CiviForm_metrics" {
 
 resource "aws_iam_role" "grafana_assume_role" {
   count = var.monitoring_stack_enabled ? 1 : 0
-  name = "${var.app_prefix}-grafana-assume-role"
+  name  = "${var.app_prefix}-grafana-assume-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -39,7 +39,7 @@ resource "aws_iam_role" "grafana_assume_role" {
 
 resource "aws_iam_policy" "civiform_monitoring_role_policy" {
   count = var.monitoring_stack_enabled ? 1 : 0
-  name = "${var.app_prefix}-civiform-monitoring-role-policy"
+  name  = "${var.app_prefix}-civiform-monitoring-role-policy"
   policy = jsonencode(
     {
       "Version" : "2012-10-17",
@@ -95,7 +95,7 @@ resource "aws_iam_policy" "civiform_monitoring_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "civiform_monitoring_role_policies_attach" {
-  count = var.monitoring_stack_enabled ? 1 : 0
+  count      = var.monitoring_stack_enabled ? 1 : 0
   role       = aws_iam_role.grafana_assume_role.name
   policy_arn = aws_iam_policy.civiform_monitoring_role_policy.arn
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -154,6 +154,12 @@
     "tfvar": true,
     "type": "integer"
   },
+  "MONITORING_STACK_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
   "POSTGRES_INSTANCE_CLASS": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -657,6 +657,12 @@ variable "bypass_login_language_screens" {
   default     = false
 }
 
+variable "monitoring_stack_enabled" {
+  type        = bool
+  description = "If true, Prometheus and Grafana instances are created and the metrics scraper container is included in the ECS task definition."
+  default     = true
+}
+
 variable "phone_question_type_enabled" {
   type        = bool
   description = "Whether to enable the phone question type."

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -659,7 +659,7 @@ variable "bypass_login_language_screens" {
 
 variable "monitoring_stack_enabled" {
   type        = bool
-  description = "If true, Prometheus and Grafana instances are created and the metrics scraper container is included in the ECS task definition."
+  description = "If true, Prometheus and Grafana instances are created."
   default     = true
 }
 

--- a/cloud/shared/bin/lib/terraform.py
+++ b/cloud/shared/bin/lib/terraform.py
@@ -145,8 +145,8 @@ def perform_apply(
         if "Error acquiring the state lock" in output:
             # Lock ID is a standard UUID v4 in the form 00000000-0000-0000-0000-000000000000
             match = re.search(
-                    r'ID:\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
-                    output)
+                r'ID:\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
+                output)
             error_text = inspect.cleandoc(
                 """
                 The Terraform state lock can not be acquired.


### PR DESCRIPTION
Adds a variable that controls whether or not to create Prometheus and Grafana instances in AWS. This is intended to be used for staging environments where the deployer doesn't want monitoring and would like to save on the expense.

Tested: ran `bin/deploy` for an existing deployment which reported that existing prometheus and grafana resources are moved i.e. not destroyed and replaced:
```
  # aws_grafana_workspace.CiviForm_metrics has moved to aws_grafana_workspace.CiviForm_metrics[0]
    resource "aws_grafana_workspace" "CiviForm_metrics" {
        id                        = "g-866ca756db"
        name                      = "cf-test-civiform-metrics"
        tags                      = {}
        # (13 unchanged attributes hidden)
    }

  # aws_prometheus_workspace.metrics has moved to aws_prometheus_workspace.metrics[0]
    resource "aws_prometheus_workspace" "metrics" {
        id                  = "ws-4caf9bf0-89c9-4047-8239-6cca617f4621"
        tags                = {}
        # (4 unchanged attributes hidden)
    }
```