### PR TITLE
Fix github action to push image

### DIFF
--- a/.github/workflows/push_monitoring_image.yaml
+++ b/.github/workflows/push_monitoring_image.yaml
@@ -42,5 +42,5 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         if: contains(toJSON(steps.file_changes.outputs.all_changed_files), 'cloud/aws/metrics/')
         run: |
-          cd $GITHUB_WORKSPACE/civiform-cloud-deploy-infra/cloud/aws/metrics
+          cd $GITHUB_WORKSPACE/cloud/aws/metrics
           | ./build-scraper


### PR DESCRIPTION
I'm getting an [error](https://github.com/civiform/cloud-deploy-infra/actions/runs/7131087493/job/19418919745) when trying to push the monitoring image from a branch. I noticed we cd into a directory that doesn't exist in the cloud-deploy-infra repo. Trying to remove that directory to see if that fixes the issue.