### PR TITLE
Add variables for container memory and memory reservation

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -35,8 +35,8 @@ module "civiform_server_container_def" {
 
   container_name               = "${var.app_prefix}-civiform"
   container_image              = "${var.civiform_image_repo}:${var.image_tag}"
-  container_memory             = 4096
-  container_memory_reservation = 2048
+  container_memory             = var.ecs_server_container_memory
+  container_memory_reservation = var.ecs_server_container_memory_reservation
 
   secrets = [
     {
@@ -134,8 +134,8 @@ module "civiform_metrics_scraper_container_def" {
 
   container_name               = "${var.app_prefix}-metrics-scraper"
   container_image              = var.scraper_image
-  container_memory             = 2048
-  container_memory_reservation = 1024
+  container_memory             = var.ecs_metrics_scraper_container_memory
+  container_memory_reservation = var.ecs_metrics_scraper_container_memory_reservation
 
   map_environment = merge({
     PROMETHEUS_WRITE_ENDPOINT = var.monitoring_stack_enabled ? "${aws_prometheus_workspace.metrics[0].prometheus_endpoint}api/v1/remote_write" : ""

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -285,6 +285,30 @@
     "tfvar": true,
     "type": "integer"
   },
+  "ECS_SERVER_CONTAINER_MEMORY": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
+  "ECS_SERVER_CONTAINER_MEMORY_RESERVATION": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
+  "ECS_METRICS_SCRAPER_CONTAINER_MEMORY": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
+  "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
   "ECS_MAX_CPU_THRESHOLD": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -358,7 +358,7 @@ output "validate_container_memory" {
   value = null
 
   precondition {
-    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
+    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
     error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -331,6 +331,46 @@ variable "ecs_task_memory" {
   default     = 6144
 }
 
+variable "ecs_server_container_memory" {
+  type        = number
+  description = "The amount (in MiB) of memory to present to the server container."
+  default     = 4096
+  validation {
+    condition = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
+    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+  }
+}
+
+variable "ecs_server_container_memory_reservation" {
+  type        = number
+  description = "The soft limit (in MiB) of memory to reserve for the server container."
+  default     = 2048
+  validation {
+    condition = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
+    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+  }
+}
+
+variable "ecs_metrics_scraper_container_memory" {
+  type        = number
+  description = "The amount (in MiB) of memory to present to the metrics scraper container."
+  default     = 2048
+  validation {
+    condition = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
+    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+  }
+}
+
+variable "ecs_metrics_scraper_container_memory_reservation" {
+  type        = number
+  description = "The soft limit (in MiB) of memory to reserve for the metrics scraper container."
+  default     = 1024
+  validation {
+    condition = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
+    error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
+  }
+}
+
 variable "ecs_max_cpu_threshold" {
   type        = string
   description = "The threshold for max CPU usage in an ECS task. If the CPU increases above this threshold, there will be a cloudwatch alarm and another ECS task will be added."

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -357,8 +357,10 @@ variable "ecs_metrics_scraper_container_memory_reservation" {
 output "validate_container_memory" {
   value = null
 
-  condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
-  error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+  precondition {
+    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
+    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+  }
 }
 
 # This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -335,38 +335,42 @@ variable "ecs_server_container_memory" {
   type        = number
   description = "The amount (in MiB) of memory to present to the server container."
   default     = 4096
-  validation {
-    condition = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
-    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
-  }
 }
 
 variable "ecs_server_container_memory_reservation" {
   type        = number
   description = "The soft limit (in MiB) of memory to reserve for the server container."
   default     = 2048
-  validation {
-    condition = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
-    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
-  }
 }
 
 variable "ecs_metrics_scraper_container_memory" {
   type        = number
   description = "The amount (in MiB) of memory to present to the metrics scraper container."
   default     = 2048
-  validation {
-    condition = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
-    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
-  }
 }
 
 variable "ecs_metrics_scraper_container_memory_reservation" {
   type        = number
   description = "The soft limit (in MiB) of memory to reserve for the metrics scraper container."
   default     = 1024
-  validation {
-    condition = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
+}
+
+# This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
+locals {
+  server_memory_validation = {
+    condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
+    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+  }
+  server_memory_res_validation = {
+    condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
+    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+  }
+  metrics_scraper_memory_validation = {
+    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
+    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+  }
+  metrics_scraper_memory_res_validation = {
+    condition     = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
     error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -331,6 +331,16 @@ variable "ecs_task_memory" {
   default     = 6144
 }
 
+# This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
+output "validate_container_memory" {
+  value = null
+
+  precondition {
+    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
+    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+  }
+}
+
 variable "ecs_server_container_memory" {
   type        = number
   description = "The amount (in MiB) of memory to present to the server container."
@@ -341,6 +351,16 @@ variable "ecs_server_container_memory_reservation" {
   type        = number
   description = "The soft limit (in MiB) of memory to reserve for the server container."
   default     = 2048
+}
+
+# This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
+output "validate_server_memory_reservation" {
+  value = null
+
+  precondition {
+    condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
+    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+  }
 }
 
 variable "ecs_metrics_scraper_container_memory" {
@@ -354,41 +374,16 @@ variable "ecs_metrics_scraper_container_memory_reservation" {
   description = "The soft limit (in MiB) of memory to reserve for the metrics scraper container."
   default     = 1024
 }
-output "validate_container_memory" {
+
+# This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
+output "validate_metrics_scraper_memory_reservation" {
   value = null
 
   precondition {
-    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
-    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+    condition     = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
+    error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
   }
 }
-
-# This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
-#locals {
-#  total_container_memory_validation = {
-#    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
-#    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
-#  }
-#  total_container_memory_validation_check = (var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory) ? tobool("The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY") : true
-#  server_memory_res_validation = {
-#    condition     = var.ecs_server_container_memory < var.ecs_server_container_memory_reservation
-#    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
-#  }
-#  server_memory_res_validation_check = regex(
-#    "^${local.server_memory_res_validation.error_message}$",
-#    (!local.server_memory_res_validation.condition
-#      ? local.server_memory_res_validation.error_message
-#  : ""))
-#  metrics_scraper_memory_res_validation = {
-#    condition     = var.ecs_metrics_scraper_container_memory < var.ecs_metrics_scraper_container_memory_reservation
-#    error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
-#  }
-#  metrics_scraper_memory_res_validation_check = regex(
-#    "^${local.metrics_scraper_memory_res_validation.error_message}$",
-#    (!local.metrics_scraper_memory_res_validation.condition
-#      ? local.metrics_scraper_memory_res_validation.error_message
-#  : ""))
-#}
 
 variable "ecs_max_cpu_threshold" {
   type        = string

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -354,37 +354,39 @@ variable "ecs_metrics_scraper_container_memory_reservation" {
   description = "The soft limit (in MiB) of memory to reserve for the metrics scraper container."
   default     = 1024
 }
+output "validate_container_memory" {
+  value = null
+
+  condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
+  error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+}
 
 # This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
-locals {
-  total_container_memory_validation = {
-    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
-    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
-  }
-  total_container_memory_validation_check = regex(
-    "^${local.total_container_memory_validation.error_message}$",
-    (!local.total_container_memory_validation.condition
-      ? local.total_container_memory_validation.error_message
-  : ""))
-  server_memory_res_validation = {
-    condition     = var.ecs_server_container_memory < var.ecs_server_container_memory_reservation
-    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
-  }
-  server_memory_res_validation_check = regex(
-    "^${local.server_memory_res_validation.error_message}$",
-    (!local.server_memory_res_validation.condition
-      ? local.server_memory_res_validation.error_message
-  : ""))
-  metrics_scraper_memory_res_validation = {
-    condition     = var.ecs_metrics_scraper_container_memory < var.ecs_metrics_scraper_container_memory_reservation
-    error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
-  }
-  metrics_scraper_memory_res_validation_check = regex(
-    "^${local.metrics_scraper_memory_res_validation.error_message}$",
-    (!local.metrics_scraper_memory_res_validation.condition
-      ? local.metrics_scraper_memory_res_validation.error_message
-  : ""))
-}
+#locals {
+#  total_container_memory_validation = {
+#    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
+#    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+#  }
+#  total_container_memory_validation_check = (var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory) ? tobool("The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY") : true
+#  server_memory_res_validation = {
+#    condition     = var.ecs_server_container_memory < var.ecs_server_container_memory_reservation
+#    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+#  }
+#  server_memory_res_validation_check = regex(
+#    "^${local.server_memory_res_validation.error_message}$",
+#    (!local.server_memory_res_validation.condition
+#      ? local.server_memory_res_validation.error_message
+#  : ""))
+#  metrics_scraper_memory_res_validation = {
+#    condition     = var.ecs_metrics_scraper_container_memory < var.ecs_metrics_scraper_container_memory_reservation
+#    error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
+#  }
+#  metrics_scraper_memory_res_validation_check = regex(
+#    "^${local.metrics_scraper_memory_res_validation.error_message}$",
+#    (!local.metrics_scraper_memory_res_validation.condition
+#      ? local.metrics_scraper_memory_res_validation.error_message
+#  : ""))
+#}
 
 variable "ecs_max_cpu_threshold" {
   type        = string

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -360,14 +360,29 @@ locals {
   total_container_memory_validation = {
     condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
     error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
+    validate = regex(
+      "^${local.total_container_memory_validation.error_message}$",
+      (!local.total_container_memory_validation.condition
+        ? local.total_container_memory_validation.error_message
+    : ""))
   }
   server_memory_res_validation = {
     condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
     error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+    validate = regex(
+      "^${local.server_memory_res_validation.error_message}$",
+      (!local.server_memory_res_validation.condition
+        ? local.server_memory_res_validation.error_message
+    : ""))
   }
   metrics_scraper_memory_res_validation = {
     condition     = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
     error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
+    validate = regex(
+      "^${local.metrics_scraper_memory_res_validation.error_message}$",
+      (!local.metrics_scraper_memory_res_validation.condition
+        ? local.metrics_scraper_memory_res_validation.error_message
+    : ""))
   }
 }
 

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -357,17 +357,13 @@ variable "ecs_metrics_scraper_container_memory_reservation" {
 
 # This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
 locals {
-  server_memory_validation = {
-    condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
-    error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
+  total_container_memory_validation = {
+    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
+    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
   }
   server_memory_res_validation = {
     condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
     error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
-  }
-  metrics_scraper_memory_validation = {
-    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
-    error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
   }
   metrics_scraper_memory_res_validation = {
     condition     = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -358,7 +358,7 @@ variable "ecs_metrics_scraper_container_memory_reservation" {
 # This is a workaround for validation until terraform supports conditions referring to other variables (https://github.com/hashicorp/terraform/issues/25609)
 locals {
   total_container_memory_validation = {
-    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
+    condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory >= var.ecs_task_memory
     error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
   }
   total_container_memory_validation_check = regex(
@@ -367,7 +367,7 @@ locals {
       ? local.total_container_memory_validation.error_message
   : ""))
   server_memory_res_validation = {
-    condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
+    condition     = var.ecs_server_container_memory < var.ecs_server_container_memory_reservation
     error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
   }
   server_memory_res_validation_check = regex(
@@ -376,7 +376,7 @@ locals {
       ? local.server_memory_res_validation.error_message
   : ""))
   metrics_scraper_memory_res_validation = {
-    condition     = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
+    condition     = var.ecs_metrics_scraper_container_memory < var.ecs_metrics_scraper_container_memory_reservation
     error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
   }
   metrics_scraper_memory_res_validation_check = regex(

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -360,30 +360,30 @@ locals {
   total_container_memory_validation = {
     condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
     error_message = "The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must be less than or equal to the ECS_TASK_MEMORY"
-    validate = regex(
-      "^${local.total_container_memory_validation.error_message}$",
-      (!local.total_container_memory_validation.condition
-        ? local.total_container_memory_validation.error_message
-    : ""))
   }
+  total_container_memory_validation_check = regex(
+    "^${local.total_container_memory_validation.error_message}$",
+    (!local.total_container_memory_validation.condition
+      ? local.total_container_memory_validation.error_message
+  : ""))
   server_memory_res_validation = {
     condition     = var.ecs_server_container_memory > var.ecs_server_container_memory_reservation
     error_message = "ECS_SERVER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_SERVER_CONTAINER_MEMORY"
-    validate = regex(
-      "^${local.server_memory_res_validation.error_message}$",
-      (!local.server_memory_res_validation.condition
-        ? local.server_memory_res_validation.error_message
-    : ""))
   }
+  server_memory_res_validation_check = regex(
+    "^${local.server_memory_res_validation.error_message}$",
+    (!local.server_memory_res_validation.condition
+      ? local.server_memory_res_validation.error_message
+  : ""))
   metrics_scraper_memory_res_validation = {
     condition     = var.ecs_metrics_scraper_container_memory > var.ecs_metrics_scraper_container_memory_reservation
     error_message = "ECS_METRICS_SCRAPER_CONTAINER_MEMORY_RESERVATION must be less than the ECS_METRICS_SCRAPER_CONTAINER_MEMORY"
-    validate = regex(
-      "^${local.metrics_scraper_memory_res_validation.error_message}$",
-      (!local.metrics_scraper_memory_res_validation.condition
-        ? local.metrics_scraper_memory_res_validation.error_message
-    : ""))
   }
+  metrics_scraper_memory_res_validation_check = regex(
+    "^${local.metrics_scraper_memory_res_validation.error_message}$",
+    (!local.metrics_scraper_memory_res_validation.condition
+      ? local.metrics_scraper_memory_res_validation.error_message
+  : ""))
 }
 
 variable "ecs_max_cpu_threshold" {


### PR DESCRIPTION
Add variables for container memory and memory reservation (for the server container and scraper container)

This also includes a validation to ensure we don't allow invalid variable values.

https://github.com/civiform/civiform/issues/3421

This is what one of the error messages look like on failure:

```
╷
│ Error: Module output value precondition failed
│ 
│   on variables.tf line 339, in output "validate_container_memory":
│  339:     condition     = var.ecs_server_container_memory + var.ecs_metrics_scraper_container_memory <= var.ecs_task_memory
│     ├────────────────
│     │ var.ecs_metrics_scraper_container_memory is 2048
│     │ var.ecs_server_container_memory is 4097
│     │ var.ecs_task_memory is 6144
│ 
│ The ECS_SERVER_CONTAINER_MEMORY + ECS_METRICS_SCRAPER_CONTAINER_MEMORY must
│ be less than or equal to the ECS_TASK_MEMORY
```