### PR TITLE
trim aws load balancer name to 32 characters (max size)

### DIFF
--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -26,7 +26,7 @@ resource "aws_lb_listener" "pgadmin" {
 
 # Traffic from load balancer is forwarded to IPs in this target group.
 resource "aws_lb_target_group" "pgadmin" {
-  name        = substr(local.name_prefix, 0, 32)
+  name        = local.name_prefix
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
@@ -96,7 +96,7 @@ resource "aws_ecs_service" "pgadmin" {
 
 # IAM config for pgadmin tasks.
 locals {
-  name_prefix = "${var.app_prefix}-civiform-pgadmin"
+  name_prefix = substr("${var.app_prefix}-cf-pgadmin", 0, 32)
   tags = {
     Name = "${var.app_prefix} Civiform EC2 Task Definition"
     Type = "Civiform EC2 Task Definition"

--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -26,7 +26,7 @@ resource "aws_lb_listener" "pgadmin" {
 
 # Traffic from load balancer is forwarded to IPs in this target group.
 resource "aws_lb_target_group" "pgadmin" {
-  name        = local.name_prefix
+  name        = substr(local.name_prefix, 0, 32)
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
@@ -96,7 +96,7 @@ resource "aws_ecs_service" "pgadmin" {
 
 # IAM config for pgadmin tasks.
 locals {
-  name_prefix = substr("${var.app_prefix}-cf-pgadmin", 0, 32)
+  name_prefix = "${var.app_prefix}-cf-pgadmin"
   tags = {
     Name = "${var.app_prefix} Civiform EC2 Task Definition"
     Type = "Civiform EC2 Task Definition"

--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -26,7 +26,7 @@ resource "aws_lb_listener" "pgadmin" {
 
 # Traffic from load balancer is forwarded to IPs in this target group.
 resource "aws_lb_target_group" "pgadmin" {
-  name        = local.name_prefix
+  name        = substr(local.name_prefix, 0, 32)
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"

--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -26,6 +26,7 @@ resource "aws_lb_listener" "pgadmin" {
 
 # Traffic from load balancer is forwarded to IPs in this target group.
 resource "aws_lb_target_group" "pgadmin" {
+  # AWS Load Balancer name limited to 32 characters.
   name        = substr(local.name_prefix, 0, 32)
   port        = 80
   protocol    = "HTTP"


### PR DESCRIPTION
AWS load balancer name can't be longer than 32 characters. https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-application-load-balancer.html#configure-load-balancer

```
│ Error: "name" cannot be longer than 32 characters
│ 
│   with module.pgadmin[0].aws_lb_target_group.pgadmin,
│   on ../../modules/pgadmin/main.tf line 29, in resource "aws_lb_target_group" "pgadmin":
│   29:   name        = local.name_prefix
│ 
```
