### PR TITLE
correct pgadmin prefix for secrets to reflect app name

### DIFF
--- a/cloud/aws/bin/pgadmin.py
+++ b/cloud/aws/bin/pgadmin.py
@@ -102,7 +102,7 @@ def _wait_for_pgadmin_response(url):
 
 def _print_connection_info(config, url):
     aws = AwsCli(config)
-    prefix = f"{config.app_prefix}-civiform"
+    prefix = f"{config.app_prefix}-cf"
     print(
         f"\npgamdin connection info:\n"
         f"  URL: {url}\n"

--- a/cloud/aws/bin/pgadmin.py
+++ b/cloud/aws/bin/pgadmin.py
@@ -102,13 +102,13 @@ def _wait_for_pgadmin_response(url):
 
 def _print_connection_info(config, url):
     aws = AwsCli(config)
-    prefix = f"{config.app_prefix}-cf"
+    prefix = f"{config.app_prefix}"
     print(
         f"\npgamdin connection info:\n"
         f"  URL: {url}\n"
-        f"  login email: {aws.get_secret_value(prefix + '-pgadmin-default-username')}\n"
-        f"  login password: {aws.get_secret_value(prefix + '-pgadmin-default-password')}\n"
-        f"  database password: {aws.get_secret_value(prefix + '_postgres_password')}"
+        f"  login email: {aws.get_secret_value(prefix + '-cf-pgadmin-default-username')}\n"
+        f"  login password: {aws.get_secret_value(prefix + '-cf-pgadmin-default-password')}\n"
+        f"  database password: {aws.get_secret_value(prefix + '-civiform_postgres_password')}"
     )
 
 


### PR DESCRIPTION
https://github.com/civiform/cloud-deploy-infra/pull/283 shortened civiform to "cf", but did not correct other uses. 