### PR TITLE
Create terraform variable for secret length

### DIFF
--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -79,7 +79,7 @@ resource "aws_secretsmanager_secret_version" "postgres_password_secret_version" 
 
 # Create a random generated password to use for app_secret_key.
 resource "random_password" "app_secret_key" {
-  length           = 16
+  length           = var.random_password_length
   special          = true
   override_special = "_%@"
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -382,7 +382,7 @@
     "type": "integer"
   },
   "RANDOM_PASSWORD_LENGTH": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": true,
     "type": "number"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -385,6 +385,6 @@
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -380,5 +380,11 @@
     "secret": false,
     "tfvar": true,
     "type": "integer"
+  },
+  "RANDOM_PASSWORD_LENGTH": {
+    "required": true,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -472,3 +472,9 @@ variable "monitoring_stack_enabled" {
   description = "If true, Prometheus and Grafana instances are created."
   default     = true
 }
+
+variable "random_password_length" {
+  type        = number
+  description = "Length of the random generated password to use for app_secret_key"
+  default     = 16
+}


### PR DESCRIPTION
https://github.com/civiform/civiform/issues/6506

We want to create a terraform variable for the random password length, so certain deployments can update it before they have users.

We'll need to update this before the play framework migration (https://www.playframework.com/documentation/2.9.x/Migration29#Application-Secret-enforces-a-minimum-length), and it will be easier to change the length for the deployments without many users now.