### PR TITLE
Remove todos related to server var autogeneration

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -8,10 +8,6 @@ from cloud.aws.templates.aws_oidc.bin.aws_template import AwsSetupTemplate
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 from cloud.shared.bin.lib.print import print
 
-# TODO(#3116): move these to variable_definitions.json and read docs from there.
-# Map of secrets that need to be set by the user and can't be empty values.
-# Key is the name of the secret without app prefix, value is doc shown to user
-# if the secret is unset.
 SECRETS: Dict[str, str] = {
     resources.ADFS_CLIENT_ID:
         'Client id for the ADFS configuration. Enter any value if you do not use ADFS.',

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -47,10 +47,6 @@ class ConfigLoader:
         - https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/shared/variable_definitions.json
         - https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/aws/templates/aws_oidc/variable_definitions.json
         - https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/azure/templates/azure_saml_ses/variable_definitions.json
-
-        TODO(https://github.com/civiform/civiform/issues/4293): Currently this also includes
-        the env variables that are defined in env-var-docs and passed to the server. 
-        Remove them when other required changes are completed.
         """
 
     class VersionNotFoundError(Exception):
@@ -97,13 +93,6 @@ class ConfigLoader:
     def _load_civiform_server_env_vars(self) -> dict:
         """Returns environment variables in
         https://github.com/civiform/civiform/tree/main/server/conf/env-var-docs.json.
-
-        TODO(#4612) Enable the reading of server variables. This function is currently 
-        disabled because it relies on the env_var_docs module
-        (https://github.com/civiform/civiform/tree/main/env-var-docs/parser-package)
-        being installed. If the module is not available for import, this function 
-        does nothing and returns an empty map.
-
         _load_config_fields() MUST be called before calling this function.
         """
 
@@ -282,10 +271,6 @@ class ConfigLoader:
 
         for name, variable in env_var_docs.items():
             config_value = config_fields.get(name)
-
-            # TODO(#4612) Extend env-var-docs to include the required field, use the
-            # variable_definitions.json files as the source for the values. env_var_docs does
-            # not currently include required field. Therefore this code will never run.
             if config_value is None:
                 # Vars that are admin writeable are set via the admin settings panel
                 # and are not required in the config
@@ -339,9 +324,6 @@ class ConfigLoader:
             civiform_server_env_var_definitions: dict):
         out = {}
 
-        # TODO(#4612) When server variables are not duplicated in the infra
-        # variables anymore: support the tfvars field in env-var-docs.json
-        # instead or make all server variables "tfvar"s by default.
         for name, definition in infra_variable_definitions.items():
             if not definition.get("tfvar", False):
                 continue

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -47,6 +47,10 @@ class ConfigLoader:
         - https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/shared/variable_definitions.json
         - https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/aws/templates/aws_oidc/variable_definitions.json
         - https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/azure/templates/azure_saml_ses/variable_definitions.json
+        
+        TODO(https://github.com/civiform/civiform/issues/4293): Currently this also includes
+        the env variables that are defined in env-var-docs and passed to the server.
+        Remove them when other required changes are completed.
         """
 
     class VersionNotFoundError(Exception):
@@ -343,9 +347,6 @@ class ConfigLoader:
                     else:
                         env_vars[name] = config_fields[name]
 
-            # Infra and server variables are merged before being passed through
-            # terraform, which means that, if a variable is in both, values in the server variables
-            # take precedence over infra variables. Once #4612 is completed, this should never happen.
             out[CIVIFORM_SERVER_VARIABLES_KEY] = env_vars
 
         return out

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -1,8 +1,6 @@
 #! /usr/bin/env bash
 # Script for running the commands supported by the deploy system by calling run.py.
 # See comments below for why we need this script rather than running run.py directly.
-# TODO(#4612) Enable the env-var-docs variable generation feature by using this script
-# instead of run.py across the civiform-deploy repository
 
 # In the server code repository in git(civiform), we define a python package
 # called env-var-docs: https://github.com/civiform/civiform/tree/main/env-var-docs


### PR DESCRIPTION
This PR cleans up remaining todos and comments in the deploy code related to server variable autogeneration: https://github.com/civiform/civiform/issues/4612

I also removed a TODO related to a closed issue: https://github.com/civiform/civiform/issues/3116

Part of: https://github.com/civiform/civiform/issues/5250