### PR TITLE
Remove and rename admin writeable vars

### DIFF
--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -39,10 +39,6 @@ module "app" {
 
   civiform_time_zone_id = var.civiform_time_zone_id
 
-  civic_entity_short_name            = var.civic_entity_short_name
-  civic_entity_full_name             = var.civic_entity_full_name
-  civic_entity_support_email_address = var.civic_entity_support_email_address
-  civic_entity_logo_with_name_url    = var.civic_entity_logo_with_name_url
   civic_entity_small_logo_url        = var.civic_entity_small_logo_url
 
   adfs_admin_group = var.adfs_admin_group

--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -39,7 +39,7 @@ module "app" {
 
   civiform_time_zone_id = var.civiform_time_zone_id
 
-  civic_entity_small_logo_url        = var.civic_entity_small_logo_url
+  civic_entity_small_logo_url = var.civic_entity_small_logo_url
 
   adfs_admin_group = var.adfs_admin_group
 

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -15,26 +15,6 @@ variable "civiform_time_zone_id" {
   default     = "America/Los_Angeles"
 }
 
-variable "civic_entity_short_name" {
-  type        = string
-  description = "Short name for civic entity (example: Rochester, Seattle)."
-}
-
-variable "civic_entity_full_name" {
-  type        = string
-  description = "Full name for civic entity (example: City of Rochester, City of Seattle)."
-}
-
-variable "civic_entity_support_email_address" {
-  type        = string
-  description = "Email address where applicants can contact civic entity for support with Civiform."
-}
-
-variable "civic_entity_logo_with_name_url" {
-  type        = string
-  description = "Logo with name used on the applicant-facing program index page"
-}
-
 variable "civic_entity_small_logo_url" {
   type        = string
   description = "Logo with name used on the applicant-facing program index page"

--- a/cloud/deploys/dev_azure/civiform_config.example.sh
+++ b/cloud/deploys/dev_azure/civiform_config.example.sh
@@ -4,10 +4,7 @@
 # https://docs.civiform.us/contributor-guide/developer-guide/dev-azure
 export CIVIFORM_CLOUD_PROVIDER="azure"
 export CIVIFORM_MODE="dev"
-export CIVIC_ENTITY_SHORT_NAME="Sooschester"
-export CIVIC_ENTITY_FULL_NAME="City of Sooschester"
-export CIVIC_ENTITY_SUPPORT_EMAIL_ADDRESS="civiform-azure-staging-email@googlegroups.com"
-export CIVIC_ENTITY_LOGO_WITH_NAME_URL="https://www.cityofrochester.gov/images/header-logo.png"
+export SUPPORT_EMAIL_ADDRESS="civiform-azure-staging-email@googlegroups.com"
 export CIVIC_ENTITY_SMALL_LOGO_URL="https://www.cityofrochester.gov/assets/0/117/8589934986/c6791498-270e-40b1-9b81-aca8a510c1b5.jpg"
 export CIVIFORM_TIME_ZONE_ID="America/Los_Angeles"
 export EMAIL_SENDER="ses"

--- a/e2e-test/civiform_config_aws_oidc.sh
+++ b/e2e-test/civiform_config_aws_oidc.sh
@@ -56,15 +56,15 @@ export CIVIFORM_APPLICANT_AUTH_PROTOCOL="oidc"
 
 # REQUIRED
 # The short name for the civic entity. Ex. "Rochester"
-export CIVIC_ENTITY_SHORT_NAME="E2E"
+export WHITELABEL_CIVIC_ENTITY_SHORT_NAME="E2E"
 
 # REQUIRED
 # The full name for the civic entity. Ex. "City of Rochester"
-export CIVIC_ENTITY_FULL_NAME="E2E Test City"
+export WHITELABEL_CIVIC_ENTITY_FULL_NAME="E2E Test City"
 
 # REQUIRED
 # The email address to contact for support with using Civiform. Ex. "Civiform@CityOfRochester.gov
-export CIVIC_ENTITY_SUPPORT_EMAIL_ADDRESS="civiform-deploy-e2e-tests@exygy.com"
+export SUPPORT_EMAIL_ADDRESS="civiform-deploy-e2e-tests@exygy.com"
 
 # REQUIRED
 # A link to an image of the civic entity logo that includes the entity name, to be used in the header for the "Get Benefits" page


### PR DESCRIPTION
### Description

With the introduction of server variable autogeneration, the names for variables used in the deploy system must match those in `env-var-docs.json`. Furthermore, vars that are `ADMIN_WRITABLE` shouldn't be set in the deploy system at all. This PR does some additional cleanup for these types of variables that was missed the first time around.

1. Remove `ADMIN_WRITEABLE` vars from Azure files.
2. Rename vars in the end to end test so they match server vars

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 

### Issue(s) this completes

Related to #6636
