### PR TITLE
Destroy previously created resources before re-running bin/setup

### DIFF
--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SKIP_TAG_CHECK: true
+      SKIP_USER_INPUT: true
     steps:
       - name: Check out branch
         uses: actions/checkout@v4

--- a/.github/workflows/azure-saml-ses-deploy-test.yaml
+++ b/.github/workflows/azure-saml-ses-deploy-test.yaml
@@ -22,7 +22,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_PASSWORD }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SKIP_TAG_CHECK: true
+      SKIP_USER_INPUT: true
     steps:
       - name: Check out branch
         uses: actions/checkout@v4

--- a/cloud/shared/bin/destroy_backend_state_resources.py
+++ b/cloud/shared/bin/destroy_backend_state_resources.py
@@ -1,0 +1,25 @@
+"""
+destroy_backend_state_resources.py destroys the Terraform backend state resources that are used to track 
+resources created in the cloud provider during deployment. You may wish to destroy the backend state resources
+if they get corrupted.
+"""
+from typing import List
+
+from cloud.shared.bin.lib import terraform
+from cloud.shared.bin.lib.config_loader import ConfigLoader
+from cloud.shared.bin.lib.setup_class_loader import get_config_specific_setup
+
+
+def run(config: ConfigLoader, params: List[str]):
+    template = get_config_specific_setup(config)
+    resources = template.detect_backend_state_resources()
+    if resources['bucket'] or resources['table']:
+        print(' - Found resources to destroy. Destroying backend resources...')
+        if template.destroy_backend_resources(resources):
+            print('Successfully destroyed backend state resources.')
+        else:
+            print(
+                'One or more errors occurred when attempting to delete Terraform backend state resources. Please check your cloud provider\'s console for more information.'
+            )
+    else:
+        print('No backend state resources found to destroy.')

--- a/cloud/shared/bin/destroy_backend_state_resources.py
+++ b/cloud/shared/bin/destroy_backend_state_resources.py
@@ -5,7 +5,6 @@ if they get corrupted.
 """
 from typing import List
 
-from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 from cloud.shared.bin.lib.setup_class_loader import get_config_specific_setup
 

--- a/cloud/shared/bin/run.py
+++ b/cloud/shared/bin/run.py
@@ -101,9 +101,9 @@ def validate_tag(tag):
         The provided tag "{tag}" does not reference a release tag and may not
         be stable.
         ''')
-    if os.getenv('SKIP_TAG_CHECK'):
+    if os.getenv('SKIP_USER_INPUT'):
         print(
-            'Proceeding automatically since the "SKIP_TAG_CHECK" environment variable was set.'
+            'Proceeding automatically since the "SKIP_USER_INPUT" environment variable was set.'
         )
         return True
     print(

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -78,9 +78,16 @@ def run(config: ConfigLoader, params: List[str]):
             if answer in ['y', 'Y', 'yes']:
                 destroy.run(config, [])
                 if not template_setup.destroy_backend_resources(resources):
-                    answer = input(
-                        'One or more errors occurred when attempting to delete Terraform backend state resources. You may need to delete S3 bucket and/or the DynamoDB table yourself. Continue anyway? [y/N] >'
-                    )
+                    msg = inspect.cleandoc(
+                        """
+                    One or more errors occurred when attempting to delete Terraform backend state resources.
+                    You can try destroying the backend state resources again by exiting this script
+                    and running `bin/run destroy_backend_state_resources`. If resources are corrupted,
+                    you may need to manually delete them in your cloud provider's console.
+                    
+                    Would you like to continue anyway? [y/N] >
+                    """)
+                    answer = input(msg)
                     if answer in ['n', 'N', 'no']:
                         exit(1)
             else:

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -88,7 +88,7 @@ def run(config: ConfigLoader, params: List[str]):
                         Would you like to continue anyway? [y/N] >
                         """)
                     answer = input(msg)
-                    if answer in ['n', 'N', 'no']:
+                    if answer not in ['y', 'Y', 'yes']:
                         exit(1)
             else:
                 exit(1)

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -80,13 +80,13 @@ def run(config: ConfigLoader, params: List[str]):
                 if not template_setup.destroy_backend_resources(resources):
                     msg = inspect.cleandoc(
                         """
-                    One or more errors occurred when attempting to delete Terraform backend state resources.
-                    You can try destroying the backend state resources again by exiting this script
-                    and running `bin/run destroy_backend_state_resources`. If resources are corrupted,
-                    you may need to manually delete them in your cloud provider's console.
-                    
-                    Would you like to continue anyway? [y/N] >
-                    """)
+                        One or more errors occurred when attempting to delete Terraform backend state resources.
+                        You can try destroying the backend state resources again by exiting this script
+                        and running `bin/run destroy_backend_state_resources`. If the script continues to fail,
+                        you may need to manually delete the resources in your cloud provider's console.
+                        
+                        Would you like to continue anyway? [y/N] >
+                        """)
                     answer = input(msg)
                     if answer in ['n', 'N', 'no']:
                         exit(1)

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -24,26 +24,31 @@ def run(config: ConfigLoader, params: List[str]):
     # Load Setup Class for the specific template directory
     ###############################################################################
 
-    msg = inspect.cleandoc(
-        """
-        ###########################################################################
-                                        WARNING                                                       
-        ###########################################################################
-        You are getting ready to run the setup script which will create the necessary 
-        infrastructure for CiviForm. Interrupting the script in the middle may leave 
-        your infrastructure in an inconsistent state and require you to manually 
-        clean up resources in your cloud provider's console.
-        
-        Before continuing, be sure you have at least 20 minutes free to allow the 
-        script to complete. If your initial setup failed and you are re-running 
-        this script, leave at least 30 minutes to allow time for resources to be 
-        destroyed and recreated.
+    if os.getenv('SKIP_TAG_CHECK'):
+        print(
+            'Proceeding automatically since the "SKIP_TAG_CHECK" environment variable was set.'
+        )
+    else:
+        msg = inspect.cleandoc(
+            """
+            ###########################################################################
+                                            WARNING                                                       
+            ###########################################################################
+            You are getting ready to run the setup script which will create the necessary 
+            infrastructure for CiviForm. Interrupting the script in the middle may leave 
+            your infrastructure in an inconsistent state and require you to manually 
+            clean up resources in your cloud provider's console.
+            
+            Before continuing, be sure you have at least 20 minutes free to allow the 
+            script to complete. If your initial setup failed and you are re-running 
+            this script, leave at least 30 minutes to allow time for resources to be 
+            destroyed and recreated.
 
-        Would you like to continue with the setup? [y/N] > 
-        """)
-    answer = input(msg)
-    if answer not in ['y', 'Y', 'yes']:
-        exit(1)
+            Would you like to continue with the setup? [y/N] > 
+            """)
+        answer = input(msg)
+        if answer not in ['y', 'Y', 'yes']:
+            exit(1)
 
     template_setup = get_config_specific_setup(config)
 

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -24,9 +24,9 @@ def run(config: ConfigLoader, params: List[str]):
     # Load Setup Class for the specific template directory
     ###############################################################################
 
-    if os.getenv('SKIP_TAG_CHECK'):
+    if os.getenv('SKIP_USER_INPUT'):
         print(
-            'Proceeding automatically since the "SKIP_TAG_CHECK" environment variable was set.'
+            'Proceeding automatically since the "SKIP_USER_INPUT" environment variable was set.'
         )
     else:
         msg = inspect.cleandoc(

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -43,7 +43,7 @@ def run(config: ConfigLoader, params: List[str]):
         """)
     answer = input(msg)
     if answer not in ['y', 'Y', 'yes']:
-        exit(1)        
+        exit(1)
 
     template_setup = get_config_specific_setup(config)
 


### PR DESCRIPTION
### Description

This change will make it so that the `bin/setup` script can be re-run without error. It adds a call to `terraform destroy` when backend resources are detected so that those are destroyed before deleting the Terraform state tracking resources. It also updates the feedback to the user to make it clear that:
1) They should allow the script to run to completion to avoid issues with partially created backend state
2) Destroying the backend resources is destructive and should be run with caution 

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

Updated documentation: https://github.com/civiform/docs/pull/415

### Instructions for manual testing

1. Run `bin/setup` and allow the script to run to completion
2. Run `bin/setup` again and answer "yes" to all the prompts. Existing resources should be destroyed and the setup should succeed.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/6417
