### PR TITLE
Replace url for staging config

### DIFF
--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh?token=${{ secrets.GITHUB_TOKEN }} > civiform_config.sh
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"  https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,9 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl --request GET \
-          --url "https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh" \
-          --header "Authorization: Bearer ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}" > civiform_config.sh
+          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh -H "Authorization: Bearer ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}" > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
+          curl https://github.com/civiform/civiform-staging-deploy/blob/main/aws_staging_civiform_config.sh > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh?token=${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }} > civiform_config.sh
+          curl -L -H "Authorization: Bearer ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}"  https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,9 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl --request GET \
-          --url https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' > civiform_config.sh
+          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh?token=${{ secrets.CIVIFORM_DEPLOY_TOKEN }} > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,9 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl -L -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
+          curl --request GET \
+          --url https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://github.com/civiform/civiform-staging-deploy/blob/main/aws_staging_civiform_config.sh > civiform_config.sh
+          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh?token=${{ secrets.GITHUB_TOKEN }} > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"  https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
+          curl -L -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,9 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl -L -H "Authorization: Bearer ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}"  https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
+          curl --request GET \
+          --url "https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh" \
+          --header "Authorization: Bearer ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}" > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 

--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh?token=${{ secrets.CIVIFORM_DEPLOY_TOKEN }} > civiform_config.sh
+          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh?token=${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }} > civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 


### PR DESCRIPTION
### Description

The url now requires an authorization token to fetch the staging config. I added it to secrets and referenced it here. 

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7011
