### PR TITLE
filter out new SSO role

### DIFF
--- a/e2e-test/nuke.yaml
+++ b/e2e-test/nuke.yaml
@@ -22,6 +22,9 @@ accounts:
       IAMRole:
         - "OrganizationAccountAccessRole"
         - "e2e-test-runner"
+        - "AWSReservedSSO_AdministratorAccess_b9fdec4c8250f86c"
       IAMRolePolicyAttachment:
         - "OrganizationAccountAccessRole -> AdministratorAccess"
         - "e2e-test-runner -> AdministratorAccess"
+        - "AWSReservedSSO_AdministratorAccess_b9fdec4c8250f86c -> AdministratorAccess"
+        - "AWSReservedSSO_AdministratorAccess_b9fdec4c8250f86c -> AWSAccountManagementFullAccess"


### PR DESCRIPTION
### Description

End to end tests have been failing because of the new role that was added that cannot be deleted. This PR filters this role out of the nuke config to allow the test to pass.

### Checklist

#### General

- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7084