### PR TITLE
Update aws-nuke config and version

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -40,9 +40,9 @@ jobs:
       - id: get-nuke
         name: Get aws-nuke
         run: |
-          wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.21.2/aws-nuke-v2.21.2-linux-amd64.tar.gz -O aws-nuke-v2.21.2-linux-amd64.tar.gz
-          tar -xzf aws-nuke-v2.21.2-linux-amd64.tar.gz
-          sudo mv aws-nuke-v2.21.2-linux-amd64 /aws-nuke
+          wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz -O aws-nuke-v2.21.2-linux-amd64.tar.gz
+          tar -xzf aws-nuke-v2.25.0-linux-amd64.tar.gz
+          sudo mv aws-nuke-v2.25.0-linux-amd64 /aws-nuke
           sudo chmod u+x /aws-nuke
 
       - id: get-aws-creds

--- a/e2e-test/nuke.yaml
+++ b/e2e-test/nuke.yaml
@@ -29,3 +29,10 @@ accounts:
         - "e2e-test-runner -> AdministratorAccess"
         - property: "RoleName"
           regex: "^AWSReservedSSO_.+$"
+      OpsWorksUserProfile:
+        - type: contains
+          value: "arn:aws:sts::296877675213:assumed-role"
+      OSPackage:
+        - property: "PackageName"
+          type: regex
+          value: "^(analysis-\\w+|amazon-personalized-ranking)*"


### PR DESCRIPTION
This updates to the latest version which filters some things out automatically.  It also filters some things related to assumed roles, which can royally screw things up if they get deleted, and OSPackage resources, which are OpenSearch resources always present now. A future version of aws-nuke will filter the OSPackage ones automatically, but the new version has not yet been released.