### PR TITLE
Block deployment if the app secret is less than 32 characters

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -4,9 +4,20 @@ from cloud.aws.templates.aws_oidc.bin import resources
 from cloud.aws.templates.aws_oidc.bin.aws_cli import AwsCli
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib.print import print
+from cloud.shared.bin.lib.color import Color
 
 
 def run(config):
+    aws = AwsCli(config)
+
+    if not config.is_test():
+        secret_length = aws.get_application_secret_length()
+        if secret_length < 32:
+            print(
+                f'{Color.RED}The application secret must be at least 32 characters in length, and ideally 64 characters. The current secret has a length of {secret_length}. See https://docs.civiform.us/it-manual/sre-playbook/initial-deployment/terraform-deploy-system#rotating-the-application-secret for details on how to regenerate the secret with a longer length.{Color.END}'
+            )
+            exit(1)
+
     if not terraform.perform_apply(config):
         print('Terraform deployment failed.')
         # TODO(#2606): write and upload logs.
@@ -16,7 +27,6 @@ def run(config):
         print('Test completed')
         return
 
-    aws = AwsCli(config)
     aws.wait_for_ecs_service_healthy()
     lb_dns = aws.get_load_balancer_dns(f'{config.app_prefix}-civiform-lb')
     base_url = config.get_base_url()

--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -335,6 +335,11 @@ class AwsCli:
             f"rds describe-db-instances --db-instance-identifier={self.config.app_prefix}-civiform-db --query 'DBInstances[0].Endpoint.Address'"
         )
 
+    def get_application_secret_length(self) -> int:
+        secret = self.get_secret_value(
+            f"{self.config.app_prefix}-civiform_app_secret_key")
+        return len(secret)
+
     def _call_cli(self, command: str, output: bool = True) -> Dict:
         base = f"aws --region={self.config.aws_region} "
         if output:


### PR DESCRIPTION
Play 2.9 will require the app secret to be at least 32 characters long. This adds a check to deployment to ensure it is at least that long, and fails if not.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Instructions for manual testing

Without this change, set `export RANDOM_PASSWORD_LENGTH=16`, run `bin/setup`.  Then with this change, try running `bin/deploy`, and then run it after setting `export RANDOM_PASSWORD_LENGTH=64` and running `bin/run rotate_app_secret`.

