### PR TITLE
Fix esri secret setting

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -15,7 +15,7 @@ APPLICANT_OIDC_CLIENT_ID = 'civiform_applicant_oidc_client_id'
 APPLICANT_OIDC_CLIENT_SECRET = 'civiform_applicant_oidc_client_secret'
 ADMIN_OIDC_CLIENT_ID = 'civiform_admin_oidc_client_id'
 ADMIN_OIDC_CLIENT_SECRET = 'civiform_admin_oidc_client_secret'
-ESRI_ARCGIS_API_TOKEN_SECRET = 'esri_arcgis_api_token_secret'
+ESRI_ARCGIS_API_TOKEN_SECRET = 'civiform_esri_arcgis_api_token'
 POSTGRES_PASSWORD = 'civiform_postgres_password'
 
 # Defined in cloud/aws/templates/aws_oidc/main.tf


### PR DESCRIPTION
### Description

`bin/setup` is currently throwing an error because AWS is unable to find the secret named `esri_arcgis_api_token_secret`. That's because it needs to be pre-pended with `civiform` which is set [here](https://github.com/civiform/cloud-deploy-infra/blob/bdbc123b92387eecd54e85d7837531da8c24794b/cloud/aws/templates/aws_oidc/secrets.tf#L214C29-L214C79). This pr fixes that.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary (need to extend docs on secrets, will do that as a fast follow)
### Instructions for manual testing

Run `bin/setup` from this branch.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7407