### PR TITLE
Throw error if ADMIN_WRITEABLE vars in config

### DIFF
--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -91,6 +91,7 @@ class ConfigLoader:
             answer = input(msg)
             if answer not in ['y', 'Y', 'yes']:
                 exit(1)
+
         self._export_env_variables(config_fields)
         return config_fields
 

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -87,9 +87,9 @@ class ConfigLoader:
 
                 Would you like to continue with the deploy? [y/N] > 
                 """)
-        answer = input(msg)
-        if answer not in ['y', 'Y', 'yes']:
-            exit(1)
+            answer = input(msg)
+            if answer not in ['y', 'Y', 'yes']:
+                exit(1)
         self._export_env_variables(config_fields)
         return config_fields
 

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -347,7 +347,8 @@ class ConfigLoader:
                     int(config_value)
                 except ValueError as e:
                     validation_errors.append(
-                        f'{Color.RED}{name} is required to be an integer: {e}{Color.END}')
+                        f'{Color.RED}{name} is required to be an integer: {e}{Color.END}'
+                    )
                     continue
 
             if variable.type == "bool":

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -70,6 +70,26 @@ class ConfigLoader:
         """
         config_parser = ConfigParser()
         config_fields = config_parser.parse_config(config_file)
+
+        if config_fields.get(
+                "ALLOW_ADMIN_WRITEABLE") and not os.getenv('SKIP_USER_INPUT'):
+            msg = inspect.cleandoc(
+                """
+                ###########################################################################
+                                                WARNING                                                       
+                ###########################################################################
+                ALLOW_ADMIN_WRITEABLE is set to true in your deploy config. This should only 
+                be set to true if this is the first time you are deploying and you want the custom
+                values for ADMIN_WRITEABLE to be applied. If this is not the case, 
+                please remove ALLOW_ADMIN_WRITEABLE and any ADMIN_WRITEABLE variables from 
+                your deploy config and update ADMIN_WRITEABLE variables via the admin settings
+                panel.
+
+                Would you like to continue with the deploy? [y/N] > 
+                """)
+        answer = input(msg)
+        if answer not in ['y', 'Y', 'yes']:
+            exit(1)
         self._export_env_variables(config_fields)
         return config_fields
 

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import io
 import os
 import requests

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -279,15 +279,28 @@ class ConfigLoader:
         """
         validation_errors = []
 
+        # loop through all the env_var_docs items
+        # get the name from the config field
+        # if the variable.mode.name is ADMIN_WRITEABLE and we find it in the config
+        # append an error
         for name, variable in env_var_docs.items():
+            is_admin_writeable = variable.mode.name == "ADMIN_WRITEABLE"
+
             config_value = config_fields.get(name)
             if config_value is None:
                 # Vars that are admin writeable are set via the admin settings panel
                 # and are not required in the config
-                if variable.required and not variable.mode.name == "ADMIN_WRITEABLE":
+                if variable.required and not is_admin_writeable:
                     validation_errors.append(
                         f"'{name}' is required but not set")
                 continue
+            
+            # this should work
+            # just need a config override field
+            disallow_admin_writeable = is_admin_writeable and not config_fields.get("ALLOW_ADMIN_WRITEABLE")
+            if config_value is not None and disallow_admin_writeable:
+                validation_errors.append(
+                        f"'{name}' is editable via the admin settings panel and should not be set in the config")
 
             # Variable types are 'string', 'int', 'bool', or 'index-list'.
             # Validation for 'index-list' is not implemented at this time because

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -279,10 +279,6 @@ class ConfigLoader:
         """
         validation_errors = []
 
-        # loop through all the env_var_docs items
-        # get the name from the config field
-        # if the variable.mode.name is ADMIN_WRITEABLE and we find it in the config
-        # append an error
         for name, variable in env_var_docs.items():
             is_admin_writeable = variable.mode.name == "ADMIN_WRITEABLE"
 
@@ -295,12 +291,11 @@ class ConfigLoader:
                         f"'{name}' is required but not set")
                 continue
             
-            # this should work
-            # just need a config override field
+            # Throw an error if an admin writeable var is set in the deploy config
             disallow_admin_writeable = is_admin_writeable and not config_fields.get("ALLOW_ADMIN_WRITEABLE")
             if config_value is not None and disallow_admin_writeable:
                 validation_errors.append(
-                        f"'{name}' is editable via the admin settings panel and should not be set in the config")
+                        f"'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).")
 
             # Variable types are 'string', 'int', 'bool', or 'index-list'.
             # Validation for 'index-list' is not implemented at this time because

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -11,6 +11,7 @@ import urllib.request
 from typing import List
 from typing import Optional
 
+from cloud.shared.bin.lib.color import Color
 from cloud.shared.bin.lib.config_parser import ConfigParser
 from cloud.shared.bin.lib.print import print
 from cloud.shared.bin.lib.write_tfvars import TfVarWriter
@@ -75,7 +76,7 @@ class ConfigLoader:
         if config_fields.get(
                 "ALLOW_ADMIN_WRITEABLE") and not os.getenv('SKIP_USER_INPUT'):
             msg = inspect.cleandoc(
-                """
+                f'''
                 {Color.YELLOW}
                 ###########################################################################
                                                 WARNING                                                       
@@ -89,7 +90,7 @@ class ConfigLoader:
 
                 Would you like to continue with the deploy? [y/N] > 
                 {Color.END}
-                """)
+                ''')
             answer = input(msg)
             if answer.lower() not in ['y', 'yes']:
                 exit(1)
@@ -312,7 +313,7 @@ class ConfigLoader:
                 # and are not required in the config
                 if variable.required and not is_admin_writeable:
                     validation_errors.append(
-                        f"'{name}' is required but not set")
+                        f'{Color.RED}{name} is required but not set{Color.END}')
                 continue
 
             # Throw an error if an admin writeable var is set in the deploy config
@@ -320,7 +321,7 @@ class ConfigLoader:
                 "ALLOW_ADMIN_WRITEABLE")
             if config_value is not None and disallow_admin_writeable:
                 validation_errors.append(
-                    f"'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution)."
+                    f'{Color.RED}{name} is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).{Color.END}'
                 )
 
             # Variable types are 'string', 'int', 'bool', or 'index-list'.
@@ -330,14 +331,14 @@ class ConfigLoader:
                 if variable.values is not None:
                     if config_value not in variable.values:
                         validation_errors.append(
-                            f"'{name}': '{config_value}' is not a valid value. Valid values are {variable.values}"
+                            f'{Color.RED}{name}: {config_value} is not a valid value. Valid values are {variable.values}{Color.END}'
                         )
                         continue
 
                 if variable.regex is not None:
                     if re.match(variable.regex, config_value) == None:
                         validation_errors.append(
-                            f"'{name}': '{config_value}' does not match validation regular expression '{variable.regex}'"
+                            f'{Color.RED}{name}: {config_value} does not match validation regular expression {variable.regex}{Color.END}'
                         )
                         continue
 
@@ -346,13 +347,13 @@ class ConfigLoader:
                     int(config_value)
                 except ValueError as e:
                     validation_errors.append(
-                        f"'{name}' is required to be an integer: {e}")
+                        f'{Color.RED}{name} is required to be an integer: {e}{Color.END}')
                     continue
 
             if variable.type == "bool":
                 if config_value not in ["true", "false"]:
                     validation_errors.append(
-                        f"'{name}' is required to be either 'true' or 'false', got {config_value}"
+                        f'{Color.RED}{name} is required to be either true or false, got {config_value}{Color.END}'
                     )
                     continue
 

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -290,12 +290,14 @@ class ConfigLoader:
                     validation_errors.append(
                         f"'{name}' is required but not set")
                 continue
-            
+
             # Throw an error if an admin writeable var is set in the deploy config
-            disallow_admin_writeable = is_admin_writeable and not config_fields.get("ALLOW_ADMIN_WRITEABLE")
+            disallow_admin_writeable = is_admin_writeable and not config_fields.get(
+                "ALLOW_ADMIN_WRITEABLE")
             if config_value is not None and disallow_admin_writeable:
                 validation_errors.append(
-                        f"'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).")
+                    f"'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution)."
+                )
 
             # Variable types are 'string', 'int', 'bool', or 'index-list'.
             # Validation for 'index-list' is not implemented at this time because

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -313,7 +313,8 @@ class ConfigLoader:
                 # and are not required in the config
                 if variable.required and not is_admin_writeable:
                     validation_errors.append(
-                        f'{Color.RED}{name} is required but not set{Color.END}')
+                        f"{Color.RED}'{name}' is required but not set{Color.END}"
+                    )
                 continue
 
             # Throw an error if an admin writeable var is set in the deploy config
@@ -321,7 +322,7 @@ class ConfigLoader:
                 "ALLOW_ADMIN_WRITEABLE")
             if config_value is not None and disallow_admin_writeable:
                 validation_errors.append(
-                    f'{Color.RED}{name} is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).{Color.END}'
+                    f"{Color.RED}'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).{Color.END}"
                 )
 
             # Variable types are 'string', 'int', 'bool', or 'index-list'.
@@ -331,14 +332,14 @@ class ConfigLoader:
                 if variable.values is not None:
                     if config_value not in variable.values:
                         validation_errors.append(
-                            f'{Color.RED}{name}: {config_value} is not a valid value. Valid values are {variable.values}{Color.END}'
+                            f"{Color.RED}'{name}': '{config_value}' is not a valid value. Valid values are {variable.values}{Color.END}"
                         )
                         continue
 
                 if variable.regex is not None:
                     if re.match(variable.regex, config_value) == None:
                         validation_errors.append(
-                            f'{Color.RED}{name}: {config_value} does not match validation regular expression {variable.regex}{Color.END}'
+                            f"{Color.RED}'{name}': '{config_value}' does not match validation regular expression '{variable.regex}'{Color.END}"
                         )
                         continue
 
@@ -347,14 +348,14 @@ class ConfigLoader:
                     int(config_value)
                 except ValueError as e:
                     validation_errors.append(
-                        f'{Color.RED}{name} is required to be an integer: {e}{Color.END}'
+                        f"{Color.RED}'{name}' is required to be an integer: {e}{Color.END}"
                     )
                     continue
 
             if variable.type == "bool":
                 if config_value not in ["true", "false"]:
                     validation_errors.append(
-                        f'{Color.RED}{name} is required to be either true or false, got {config_value}{Color.END}'
+                        f"{Color.RED}'{name}' is required to be either 'true' or 'false', got '{config_value}'{Color.END}"
                     )
                     continue
 

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -76,6 +76,7 @@ class ConfigLoader:
                 "ALLOW_ADMIN_WRITEABLE") and not os.getenv('SKIP_USER_INPUT'):
             msg = inspect.cleandoc(
                 """
+                {Color.YELLOW}
                 ###########################################################################
                                                 WARNING                                                       
                 ###########################################################################
@@ -87,9 +88,10 @@ class ConfigLoader:
                 panel.
 
                 Would you like to continue with the deploy? [y/N] > 
+                {Color.END}
                 """)
             answer = input(msg)
-            if answer not in ['y', 'Y', 'yes']:
+            if answer.lower() not in ['y', 'yes']:
                 exit(1)
 
         self._export_env_variables(config_fields)

--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -331,7 +331,8 @@ class TestConfigLoader(unittest.TestCase):
             values=None,
             regex=None,
             regex_tests=None,
-            mode=Mode.ADMIN_WRITEABLE) # Is admin writeable and is included in config_fields so should throw an error
+            mode=Mode.ADMIN_WRITEABLE
+        )  # Is admin writeable and is included in config_fields so should throw an error
 
         config_loader = ConfigLoader()
         validation_errors = config_loader._validate_civiform_server_env_vars(

--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -350,12 +350,12 @@ class TestConfigLoader(unittest.TestCase):
             civiform_server_env_vars, config_fields)
         self.assertEqual(
             [
-                "'FOO_0' is required but not set",
-                "'FOO_1' is required to be either 'true' or 'false', got none_boolean_string",
-                "'FOO_2': 'value3' is not a valid value. Valid values are value1, value2",
-                "'FOO_3': 'gry' does not match validation regular expression 'gr(a|e)y'",
-                "'FOO_4' is required to be an integer: invalid literal for int() with base 10: 'none_int_string'",
-                "'FOO_6' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution)."
+                '\x1b[31mFOO_0 is required but not set\x1b[0m',
+                '\x1b[31mFOO_1 is required to be either true or false, got none_boolean_string\x1b[0m',
+                '\x1b[31mFOO_2: value3 is not a valid value. Valid values are value1, value2\x1b[0m',
+                '\x1b[31mFOO_3: gry does not match validation regular expression gr(a|e)y\x1b[0m',
+                '\x1b[31mFOO_4 is required to be an integer: invalid literal for int() with base 10: none_int_string\x1b[0m',
+                '\x1b[31mFOO_6 is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).\x1b[0m'
             ], validation_errors)
 
     @patch('importlib.import_module')

--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -27,6 +27,8 @@ To run the tests: PYTHONPATH="${PYTHONPATH}:${pwd}" python3 cloud/shared/bin/lib
 
 class TestConfigLoader(unittest.TestCase):
 
+    maxDiff = None
+
     def test_validate_config_for_not_including_variable_required__in_infra_variable_definition(
             self):
         defs = {
@@ -350,12 +352,12 @@ class TestConfigLoader(unittest.TestCase):
             civiform_server_env_vars, config_fields)
         self.assertEqual(
             [
-                '\x1b[31mFOO_0 is required but not set\x1b[0m',
-                '\x1b[31mFOO_1 is required to be either true or false, got none_boolean_string\x1b[0m',
-                '\x1b[31mFOO_2: value3 is not a valid value. Valid values are value1, value2\x1b[0m',
-                '\x1b[31mFOO_3: gry does not match validation regular expression gr(a|e)y\x1b[0m',
-                '\x1b[31mFOO_4 is required to be an integer: invalid literal for int() with base 10: none_int_string\x1b[0m',
-                '\x1b[31mFOO_6 is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).\x1b[0m'
+                "\x1b[31m'FOO_0' is required but not set\x1b[0m",
+                "\x1b[31m'FOO_1' is required to be either 'true' or 'false', got 'none_boolean_string'\x1b[0m",
+                "\x1b[31m'FOO_2': 'value3' is not a valid value. Valid values are value1, value2\x1b[0m",
+                "\x1b[31m'FOO_3': 'gry' does not match validation regular expression 'gr(a|e)y'\x1b[0m",
+                "\x1b[31m'FOO_4' is required to be an integer: invalid literal for int() with base 10: 'none_int_string'\x1b[0m",
+                "\x1b[31m'FOO_6' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).\x1b[0m"
             ], validation_errors)
 
     @patch('importlib.import_module')

--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -209,7 +209,9 @@ class TestConfigLoader(unittest.TestCase):
             "FOO_1": "true",
             "FOO_2": "value1",
             "FOO_3": "grey",
-            "FOO_4": "24"
+            "FOO_4": "24",
+            "FOO_5": "writeable_var",
+            "ALLOW_ADMIN_WRITEABLE": "true"
         }
         civiform_server_env_vars = {}
         # See comments on the specifics we pass correct values for
@@ -253,6 +255,15 @@ class TestConfigLoader(unittest.TestCase):
             regex=None,
             regex_tests=None,
             mode=Mode.ADMIN_READABLE)
+        civiform_server_env_vars["FOO_5"] = env_var_docs_parser.Variable(
+            description='description',
+            type='string',
+            required=False,
+            values=None,
+            regex=None,
+            regex_tests=None,
+            mode=Mode.ADMIN_WRITEABLE
+        )  # mode is ADMIN_WRITEABLE but override is set so should be ignored
 
         config_loader = ConfigLoader()
         validation_errors = config_loader._validate_civiform_server_env_vars(
@@ -319,7 +330,7 @@ class TestConfigLoader(unittest.TestCase):
             description='description',
             type='string',
             required=
-            True,  # Required but mode is ADMIN_WRITEABLE so should be ignored
+            True,  # required and not set in config but mode is ADMIN_WRITEABLE so should be ignored
             values=None,
             regex=None,
             regex_tests=None,
@@ -332,7 +343,7 @@ class TestConfigLoader(unittest.TestCase):
             regex=None,
             regex_tests=None,
             mode=Mode.ADMIN_WRITEABLE
-        )  # Is admin writeable and is included in config_fields so should throw an error
+        )  # is included in config_fields and mode is ADMIN_WRITEABLE so should throw an error
 
         config_loader = ConfigLoader()
         validation_errors = config_loader._validate_civiform_server_env_vars(

--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -269,7 +269,8 @@ class TestConfigLoader(unittest.TestCase):
             "FOO_1": "none_boolean_string",
             "FOO_2": "value3",
             "FOO_3": "gry",
-            "FOO_4": "none_int_string"
+            "FOO_4": "none_int_string",
+            "FOO_6": "writeable_var"
         }
         civiform_server_env_vars = {}
 
@@ -323,6 +324,14 @@ class TestConfigLoader(unittest.TestCase):
             regex=None,
             regex_tests=None,
             mode=Mode.ADMIN_WRITEABLE)
+        civiform_server_env_vars["FOO_6"] = env_var_docs_parser.Variable(
+            description='description',
+            type='string',
+            required=False,
+            values=None,
+            regex=None,
+            regex_tests=None,
+            mode=Mode.ADMIN_WRITEABLE) # Is admin writeable and is included in config_fields so should throw an error
 
         config_loader = ConfigLoader()
         validation_errors = config_loader._validate_civiform_server_env_vars(
@@ -333,7 +342,8 @@ class TestConfigLoader(unittest.TestCase):
                 "'FOO_1' is required to be either 'true' or 'false', got none_boolean_string",
                 "'FOO_2': 'value3' is not a valid value. Valid values are value1, value2",
                 "'FOO_3': 'gry' does not match validation regular expression 'gr(a|e)y'",
-                "'FOO_4' is required to be an integer: invalid literal for int() with base 10: 'none_int_string'"
+                "'FOO_4' is required to be an integer: invalid literal for int() with base 10: 'none_int_string'",
+                "'FOO_6' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution)."
             ], validation_errors)
 
     @patch('importlib.import_module')


### PR DESCRIPTION
### Description

Variables that are marked as `ADMIN_WRITEABLE` in [env-var-docs.json](https://github.com/civiform/civiform/blob/main/server/conf/env-var-docs.json) are editable in the admin settings config and should not be set in the deploy configs. This change adds an error if an `ADMIN_WRITEABLE` is found in the deploy config. It also allows the ability to override this by setting `ALLOW_ADMIN_WRITEABLE=true` in the deploy config.

Notes:
- Need to check all of the config files we manage to see if we need to add `ALLOW_ADMIN_WRITEABLE=true` (I know we need to do this for staging)
- Need to update documentation
- Need to provide guidance to CEs that they might see this error if they have `ADMIN_WRITEABLE` vars in their deploy config

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary https://github.com/civiform/docs/pull/459

### Instructions for manual testing

1. Add an admin writeable variable to your deploy config (Eg. `WHITELABEL_CIVIC_ENTITY_FULL_NAME`)
2. Run `bin/setup` (or `bin/deploy` if you already have a running deployment)
3. See error
4. Add `ALLOW_ADMIN_WRITEABLE=true` to deploy config
5. Run `bin/setup` (or `bin/deploy`) again.
6. Deploy should continue as normal with no error

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/6663
