### PR TITLE
Check RANDOM_PASSWORD_LENGTH on setup

### DIFF
--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -9,6 +9,7 @@ from cloud.shared.bin.lib.setup_class_loader import get_config_specific_setup
 from cloud.shared.bin.lib.print import print
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin import destroy
+from cloud.shared.bin.lib.color import Color
 """
 Setup.py sets up and runs the initial terraform deployment. It's broken into
 2 parts:
@@ -49,6 +50,18 @@ def run(config: ConfigLoader, params: List[str]):
         answer = input(msg)
         if answer not in ['y', 'Y', 'yes']:
             exit(1)
+    secret_length = config.get_config_var("RANDOM_PASSWORD_LENGTH")
+    if not secret_length:
+        print(
+            f'{Color.RED}RANDOM_PASSWORD_LENGTH is not set in the config file. Please add {Color.CYAN}export RANDOM_PASSWORD_LENGTH=64{Color.RED} to your config file and rerun this script.{Color.END}'
+        )
+        exit(1)
+
+    if int(secret_length) < 32:
+        print(
+            f'{Color.RED}RANDOM_PASSWORD_LENGTH is currently set to {secret_length}, but it must be 32 or greater. Please add {Color.CYAN}export RANDOM_PASSWORD_LENGTH=64{Color.RED} to your config file and rerun this script.{Color.END}'
+        )
+        exit(1)
 
     template_setup = get_config_specific_setup(config)
 


### PR DESCRIPTION
Because an initial deploy will fail if the default secret length of 16 is used, this checks that RANDOM_PASSWORD_LENGTH is set in the config and is at least size 32. If not, we direct the user to set it to 64.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Issue(s) this completes
https://github.com/civiform/civiform/issues/7502
