### PR TITLE
Provide a knob to optionally skip creating the VPC related resources.

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -317,13 +317,13 @@ module "ecs_fargate_service" {
   desired_count             = var.fargate_desired_task_count
   default_certificate_arn   = var.ssl_certificate_arn
   ssl_policy                = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
-  vpc_id                    = module.vpc.vpc_id
+  vpc_id                    = local.vpc_id
   task_definition_arn       = var.monitoring_stack_enabled ? aws_ecs_task_definition.civiform_with_monitoring.arn : aws_ecs_task_definition.civiform_only.arn
   container_name            = "${var.app_prefix}-civiform"
   ecs_cluster_name          = module.ecs_cluster.aws_ecs_cluster_cluster_name
   ecs_cluster_arn           = module.ecs_cluster.aws_ecs_cluster_cluster_arn
-  private_subnets           = module.vpc.private_subnets
-  public_subnets            = module.vpc.public_subnets
+  private_subnets           = local.vpc_private_subnets
+  public_subnets            = local.vpc_public_subnets
   max_cpu_threshold         = var.ecs_max_cpu_threshold
   min_cpu_threshold         = var.ecs_min_cpu_threshold
   max_cpu_evaluation_period = var.ecs_max_cpu_evaluation_period

--- a/cloud/aws/templates/aws_oidc/external_vpc.tf
+++ b/cloud/aws/templates/aws_oidc/external_vpc.tf
@@ -1,0 +1,21 @@
+// File containing the necessary data sources if enable_managed_vpc=false
+
+data "aws_vpc" "external" {
+  count = local.enable_managed_vpc ? 0 : 1
+  id    = var.external_vpc.id
+}
+
+data "aws_db_subnet_group" "external" {
+  count = local.enable_managed_vpc ? 0 : 1
+  name  = var.external_vpc.database_subnet_group_name
+}
+
+data "aws_subnet" "external_private" {
+  count = local.enable_managed_vpc ? 0 : 1
+  id    = var.external_vpc.private_subnet_id
+}
+
+data "aws_subnet" "external_public" {
+  count = local.enable_managed_vpc ? 0 : 1
+  id    = var.external_vpc.public_subnet_id
+}

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -51,7 +51,7 @@ resource "aws_db_instance" "civiform" {
   username                        = aws_secretsmanager_secret_version.postgres_username_secret_version.secret_string
   password                        = aws_secretsmanager_secret_version.postgres_password_secret_version.secret_string
   vpc_security_group_ids          = [aws_security_group.rds.id]
-  db_subnet_group_name            = module.vpc.database_subnet_group_name
+  db_subnet_group_name            = local.vpc_database_subnet_group_name
   parameter_group_name            = aws_db_parameter_group.civiform.name
   publicly_accessible             = false
   skip_final_snapshot             = local.skip_final_snapshot
@@ -116,7 +116,7 @@ resource "aws_security_group" "rds" {
     Type = "Civiform DB Security Group"
   }
   name   = "${var.app_prefix}-civiform_rds"
-  vpc_id = module.vpc.vpc_id
+  vpc_id = local.vpc_id
 
   ingress {
     from_port = 5432
@@ -148,14 +148,14 @@ module "pgadmin" {
   app_prefix = var.app_prefix
   aws_region = var.aws_region
 
-  vpc_id          = module.vpc.vpc_id
+  vpc_id          = local.vpc_id
   lb_arn          = module.ecs_fargate_service.aws_lb_civiform_lb_arn
   lb_ssl_cert_arn = var.ssl_certificate_arn
   lb_access_sg_id = module.ecs_fargate_service.aws_security_group_lb_access_sg_id
   cidr_allowlist  = var.pgadmin_cidr_allowlist
 
   ecs_cluster_arn = module.ecs_cluster.aws_ecs_cluster_cluster_arn
-  subnet_ids      = module.vpc.private_subnets
+  subnet_ids      = local.vpc_private_subnets
 
   db_sg_id               = aws_security_group.rds.id
   db_address             = data.aws_db_instance.civiform.address
@@ -173,9 +173,9 @@ module "dbaccess" {
   app_prefix = var.app_prefix
   aws_region = var.aws_region
 
-  vpc_id         = module.vpc.vpc_id
+  vpc_id         = local.vpc_id
   cidr_allowlist = var.dbaccess_cidr_allowlist
   db_sg_id       = aws_security_group.rds.id
   public_key     = var.dbaccess_public_key
-  public_subnet  = module.vpc.public_subnets[0]
+  public_subnet  = local.vpc_public_subnets[0]
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -507,3 +507,14 @@ variable "postgresql_major_version" {
   description = "Major version of PostgreSQL to use"
   default     = 16
 }
+
+variable "external_vpc" {
+  type        = map(string)
+  description = "A map with external VPC settings"
+  default = {
+    database_subnet_group_name = ""
+    id                         = ""
+    private_subnet_id          = ""
+    public_subnet_id           = ""
+  }
+}


### PR DESCRIPTION
### Description

Provide a `var.external_vpc` to specify the VPC settings that are not managed by the Terraform configs.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Tested by patching this change to the checkout folder against my dev environment, **w/o** `vars.external_vpc`.

(NOTE: it will be difficult to test **w/** `vars.external_vpc`, as Terraform will try go destroy some resources that are no longer generated)

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
