### PR TITLE
Update deploy to handle PG 12.19

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -59,6 +59,7 @@ def _check_for_postgres_upgrade(config: ConfigLoader, aws: AwsCli):
     upgrade_path = {
         '12.17': '16.1',
         '12.18': '16.2',
+        '12.19': '16.3',
     }
 
     specified_version = config.get_config_var('POSTGRESQL_VERSION') or \


### PR DESCRIPTION
### Description

RDS now supports 12.19 and 16.3, and 12.19 can only upgrade to 16.3, so this adds it to the table of upgrade paths.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
