### PR TITLE
Put enable_managd_vpc in separate local block

### DIFF
--- a/cloud/aws/templates/aws_oidc/vpc.tf
+++ b/cloud/aws/templates/aws_oidc/vpc.tf
@@ -11,11 +11,14 @@ locals {
     var.external_vpc.private_subnet_id == "",
     var.external_vpc.public_subnet_id == "",
   ])
+}
 
-  vpc_id                         = enable_managed_vpc ? module.vpc[0].vpc_id : data.aws_vpc.external[0].id
-  vpc_private_subnets            = enable_managed_vpc ? module.vpc[0].private_subnets : data.aws_subnet.external_private[*].id
-  vpc_public_subnets             = enable_managed_vpc ? module.vpc[0].public_subnets : data.aws_subnet.external_public[*].id
-  vpc_database_subnet_group_name = enable_managed_vpc ? module.vpc[0].database_subnet_group_name : data.aws_db_subnet_group.external[0].name
+locals {
+
+  vpc_id                         = local.enable_managed_vpc ? module.vpc[0].vpc_id : data.aws_vpc.external[0].id
+  vpc_private_subnets            = local.enable_managed_vpc ? module.vpc[0].private_subnets : data.aws_subnet.external_private[*].id
+  vpc_public_subnets             = local.enable_managed_vpc ? module.vpc[0].public_subnets : data.aws_subnet.external_public[*].id
+  vpc_database_subnet_group_name = local.enable_managed_vpc ? module.vpc[0].database_subnet_group_name : data.aws_db_subnet_group.external[0].name
 }
 
 module "vpc" {


### PR DESCRIPTION
### Description

We were getting an [error](https://github.com/seattle-civiform/civiform-deploy-tf/actions/runs/9269131280/job/25499290742) with the staging deployment related to the new vpc changes.


│ Error: Invalid reference
│ 
│   on vpc.tf line 15, in locals:
│   15:   vpc_id                         = **enable_managed_vpc** ? module.vpc[0].vpc_id : data.aws_vpc.external[0].id
│ 
│ A reference to a resource type must be followed by at least one attribute
│ access, specifying the resource name.
╵

This puts enable_managd_vpc in a separate local block and adds the local prefix.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
