### PR TITLE
Allow setting the external vpc related variables from config script.

### DIFF
--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -398,5 +398,29 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
+  },
+  "EXTERNAL_VPC_DATABASE_SUBNET_GROUP_NAME": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "EXTERNAL_VPC_ID": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "EXTERNAL_VPC_PRIVATE_SUBNET_ID": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "EXTERNAL_VPC_PUBLIC_SUBNET_ID": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -508,13 +508,26 @@ variable "postgresql_version" {
   default     = "16"
 }
 
-variable "external_vpc" {
-  type        = map(string)
-  description = "A map with external VPC settings. All values need to set to use an external VPC (VPC resources not managed by this Terraform config)"
-  default = {
-    database_subnet_group_name = ""
-    id                         = ""
-    private_subnet_id          = ""
-    public_subnet_id           = ""
-  }
+variable "external_vpc_database_subnet_group_name" {
+  type        = string
+  description = "The externally managed database subnet group name."
+  default     = ""
+}
+
+variable "external_vpc_id" {
+  type        = string
+  description = "The externally managed VPC's ID."
+  default     = ""
+}
+
+variable "external_vpc_private_subnet_id" {
+  type        = string
+  description = "The externally managed VPC's private subnet ID."
+  default     = ""
+}
+
+variable "external_vpc_public_subnet_id" {
+  type        = string
+  description = "The externally managed VPC's public subnet ID."
+  default     = ""
 }

--- a/cloud/aws/templates/aws_oidc/vpc.tf
+++ b/cloud/aws/templates/aws_oidc/vpc.tf
@@ -6,10 +6,10 @@ locals {
   // If any field of var.external_vpc is not set, we will switch to use the
   // managed VPC (use this Terraform config to create the VPC network).
   enable_managed_vpc = anytrue([
-    var.external_vpc.database_subnet_group_name == "",
-    var.external_vpc.id == "",
-    var.external_vpc.private_subnet_id == "",
-    var.external_vpc.public_subnet_id == "",
+    var.external_vpc_database_subnet_group_name == "",
+    var.external_vpc_id == "",
+    var.external_vpc_private_subnet_id == "",
+    var.external_vpc_public_subnet_id == "",
   ])
 }
 


### PR DESCRIPTION
### Description

This PR allows the external vpc related configs to be set from the `civiform_config.sh` script.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
