### PR TITLE
Add list type to acceptable variable definition types

### DIFF
--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -26,6 +26,15 @@ class ValidateVariableDefinitions:
     def __init__(self, variable_definitions={}):
         self.variable_definitions = variable_definitions
 
+        self.type_specific_validators = {
+            "float": self.validate_float_definition_type,
+            "integer": self.validate_integer_definition_type,
+            "string": self.validate_string_definition_type,
+            "enum": self.validate_enum_definition_type,
+            "bool": self.validate_bool_definition_type,
+            "list": self.validate_list_definition_type,
+        }
+
     def load_repo_variable_definitions_files(self):
         # As more variable definition files are added for each cloud provider,
         # add their paths here.
@@ -68,22 +77,13 @@ class ValidateVariableDefinitions:
             errors.append("Missing 'type' field.")
             return errors
 
-        type_specific_validators = {
-            "float": self.validate_float_definition_type,
-            "integer": self.validate_integer_definition_type,
-            "string": self.validate_string_definition_type,
-            "enum": self.validate_enum_definition_type,
-            "bool": self.validate_bool_definition_type,
-            "list": self.validate_list_definition_type,
-        }
-
-        validator = type_specific_validators.get(
+        validator = self.type_specific_validators.get(
             variable_definition["type"], None)
 
         if validator:
             errors.extend(validator(variable_definition))
         else:
-            supported_typed = list(type_specific_validators.keys())
+            supported_typed = list(self.type_specific_validators.keys())
             errors.append(
                 f"Unknown or missing 'type' field. Supported types {supported_typed}"
             )
@@ -103,15 +103,13 @@ class ValidateVariableDefinitions:
         errors = []
 
         list_type = variable_definition.get("list_type", None)
-        supported_types = list(type_specific_validators.keys()
+        supported_types = list(self.type_specific_validators.keys())
         
         if list_type is None:
             errors.append("'list_type' field is required for list type variables.")
         elif list_type not in supported_types):
-            errors.append(
-                f"Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}."
-            )
-    
+            errors.append("Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}." )
+        
         return errors
 
     def validate_string_definition_type(self, variable_definition):

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -98,18 +98,21 @@ class ValidateVariableDefinitions:
 
     def validate_bool_definition_type(self, variable_definition):
         return []
-        
+
     def validate_list_definition_type(self, variable_definition):
         errors = []
 
         list_type = variable_definition.get("list_type", None)
         supported_types = list(self.type_specific_validators.keys())
-        
+
         if list_type is None:
-            errors.append("'list_type' field is required for list type variables.")
-        elif list_type not in supported_types):
-            errors.append("Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}." )
-        
+            errors.append(
+                "'list_type' field is required for list type variables.")
+        elif list_type not in supported_types:
+            errors.append(
+                "Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}."
+            )
+
         return errors
 
     def validate_string_definition_type(self, variable_definition):

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -110,7 +110,7 @@ class ValidateVariableDefinitions:
                 "'list_type' field is required for list type variables.")
         elif list_type not in supported_types:
             errors.append(
-                "Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}."
+                f"Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}."
             )
 
         return errors

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -74,6 +74,7 @@ class ValidateVariableDefinitions:
             "string": self.validate_string_definition_type,
             "enum": self.validate_enum_definition_type,
             "bool": self.validate_bool_definition_type,
+            "list": self.validate_list_definition_type,
         }
 
         validator = type_specific_validators.get(
@@ -97,6 +98,21 @@ class ValidateVariableDefinitions:
 
     def validate_bool_definition_type(self, variable_definition):
         return []
+        
+    def validate_list_definition_type(self, variable_definition):
+        errors = []
+
+        list_type = variable_definition.get("list_type", None)
+        supported_types = list(type_specific_validators.keys()
+        
+        if list_type is None:
+            errors.append("'list_type' field is required for list type variables.")
+        elif list_type not in supported_types):
+            errors.append(
+                f"Invalid 'list_type' value '{list_type}'. Supported types are {supported_types}."
+            )
+    
+        return errors
 
     def validate_string_definition_type(self, variable_definition):
         maybe_value_regex = variable_definition.get("value_regex", None)

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -231,6 +231,36 @@ class TestValidateVariableDefinitions(unittest.TestCase):
                     ]
             })
 
+    def test_get_validation_errors_list_no_errors(self):
+        defs = {
+            "FOO":
+                {
+                    "required": True,
+                    "secret": False,
+                    "tfvar": False,
+                    "type": "list",
+                    "list_type": "string"
+                }
+        }
+
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
+
+        self.assertEqual(errors, {})
+
+    def test_get_validation_errors_list_invalid_list_type(self):
+        defs = {"FOO": 
+                {
+                    "required": True,
+                    "secret": False,
+                    "tfvar": False,
+                    "type": "list",
+                    "list_type": "test"
+                }}
+
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
+
+        self.assertEqual(errors, {"FOO": ["Missing 'secret' field."]})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -265,9 +265,7 @@ class TestValidateVariableDefinitions(unittest.TestCase):
             errors, {
                 "FOO":
                     [
-                        "Invalid 'list_type' value 'test'. Supported types are "
-                        'integer', 'string', 'enum', 'bool', 'list'
-                        ""
+                        "Invalid 'list_type' value 'test'. Supported types are ['float', 'integer', 'string', 'enum', 'bool', 'list']."
                     ]
             })
 

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -248,14 +248,16 @@ class TestValidateVariableDefinitions(unittest.TestCase):
         self.assertEqual(errors, {})
 
     def test_get_validation_errors_list_invalid_list_type(self):
-        defs = {"FOO": 
+        defs = {
+            "FOO":
                 {
                     "required": True,
                     "secret": False,
                     "tfvar": False,
                     "type": "list",
                     "list_type": "test"
-                }}
+                }
+        }
 
         errors = ValidateVariableDefinitions(defs).get_validation_errors()
 

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -261,7 +261,15 @@ class TestValidateVariableDefinitions(unittest.TestCase):
 
         errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
-        self.assertEqual(errors, {"FOO": ["Invalid 'list_type' value 'test'. Supported types are "]})
+        self.assertEqual(
+            errors, {
+                "FOO":
+                    [
+                        "Invalid 'list_type' value 'test'. Supported types are "
+                        'integer', 'string', 'enum', 'bool', 'list'
+                        ""
+                    ]
+            })
 
 
 if __name__ == '__main__':

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -261,7 +261,7 @@ class TestValidateVariableDefinitions(unittest.TestCase):
 
         errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
-        self.assertEqual(errors, {"FOO": ["Missing 'secret' field."]})
+        self.assertEqual(errors, {"FOO": ["Invalid 'list_type' value 'test'. Supported types are "]})
 
 
 if __name__ == '__main__':

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -247,6 +247,23 @@ class TestValidateVariableDefinitions(unittest.TestCase):
 
         self.assertEqual(errors, {})
 
+    def test_get_validation_errors_list_unset_list_type(self):
+        defs = {
+            "FOO":
+                {
+                    "required": True,
+                    "secret": False,
+                    "tfvar": False,
+                    "type": "list"
+                }
+        }
+
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
+
+        self.assertEqual(
+            errors,
+            {"FOO": ["'list_type' field is required for list type variables."]})
+
     def test_get_validation_errors_list_invalid_list_type(self):
         defs = {
             "FOO":


### PR DESCRIPTION
### Description

Add support for list type, since we want to add a variable for private and public subnets, which will be a list of strings

This will be used to support a list of public and private subnets from Charlotte (https://github.com/civiform/civiform/issues/7648)

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7750
