### PR TITLE
Add support for terraform list variables 

### DIFF
--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -12,11 +12,11 @@ import unittest.mock
 from unittest.mock import MagicMock, patch
 from urllib.request import urlopen
 
-from cloud.shared.bin.lib.config_loader import (
-    CIVIFORM_SERVER_VARIABLES_KEY, ConfigLoader)
+from cloud.shared.bin.lib.config_loader import ConfigLoader
 from cloud.shared.bin.lib.mock_env_var_docs_parser import (
     Variable, Mode, import_mock_env_var_docs_parser,
     install_mock_env_var_docs_package)
+from cloud.shared.bin.lib.variables import Variables
 """
 Tests for the ConfigLoader, calls the I/O methods to match the actual
 experience of running the class.
@@ -381,6 +381,14 @@ class TestConfigLoader(unittest.TestCase):
                     "tfvar": True,
                     "type": "string"
                 },
+            "FOO_2":
+                {
+                    "required": False,
+                    "secret": False,
+                    "tfvar": True,
+                    "type": "list",
+                    "list_type": "string"
+                },
         }
         config_loader._infra_variable_definitions = defs
 
@@ -405,14 +413,18 @@ class TestConfigLoader(unittest.TestCase):
                 mode=Mode.ADMIN_READABLE)
         config_loader._config_fields = config_fields = {
             "FOO_0": "item0, item1, item2",
-            "FOO_1": "normal string"
+            "FOO_1": "normal string",
+            "FOO_2": ["test1", "test2"]
         }
 
         terraform_vars = config_loader.get_terraform_variables()
-        self.assertEqual(2, len(terraform_vars))
+        self.assertEqual(3, len(terraform_vars))
         self.assertEqual(terraform_vars["FOO_1"], "normal string")
 
-        server_vars = terraform_vars[CIVIFORM_SERVER_VARIABLES_KEY]
+        list_vars = terraform_vars[Variables.TERRAFORM_LIST_VARIABLES_KEY]
+        self.assertEqual(list_vars["FOO_2"], ["test1", "test2"])
+
+        server_vars = terraform_vars[Variables.CIVIFORM_SERVER_VARIABLES_KEY]
         self.assertEqual(server_vars["FOO_1"], "normal string")
         self.assertEqual(server_vars["FOO_0.0"], "item0")
         self.assertEqual(server_vars["FOO_0.1"], "item1")

--- a/cloud/shared/bin/lib/variables.py
+++ b/cloud/shared/bin/lib/variables.py
@@ -1,0 +1,3 @@
+class Variables:
+    CIVIFORM_SERVER_VARIABLES_KEY = "civiform_server_environment_variables"
+    TERRAFORM_LIST_VARIABLES_KEY = "terraform_list_variables"

--- a/cloud/shared/bin/lib/write_tfvars.py
+++ b/cloud/shared/bin/lib/write_tfvars.py
@@ -6,6 +6,8 @@ If we want to store non string values here we will need to add in the variables
 and do a lil more advanced file writing
 """
 
+from cloud.shared.bin.lib.variables import Variables
+
 
 class TfVarWriter:
 
@@ -17,14 +19,20 @@ class TfVarWriter:
         with open(self.filepath, "w") as tf_vars_file:
             for name, definition in config_vars.items():
                 # Special key that has a dict value.
-                if name == "civiform_server_environment_variables":
+                if name == Variables.CIVIFORM_SERVER_VARIABLES_KEY:
                     tf_vars_file.write(
-                        "civiform_server_environment_variables = {\n")
+                        f"{Variables.CIVIFORM_SERVER_VARIABLES_KEY} = {{\n")
                     for key, value in definition.items():
                         if value is not None:
                             tf_vars_file.write(f'  "{key}"="{value}"\n')
                     tf_vars_file.write("}\n")
                     continue
 
-                if definition is not None:
+                # Special handling for "list" type variables
+                if name == Variables.TERRAFORM_LIST_VARIABLES_KEY:
+                    for key, value in definition.items():
+                        if value is not None:
+                            tf_vars_file.write(f'{key.lower()}={value}\n')
+
+                elif definition is not None:
                     tf_vars_file.write(f'{name.lower()}="{definition}"\n')

--- a/cloud/shared/bin/lib/write_tfvars_test.py
+++ b/cloud/shared/bin/lib/write_tfvars_test.py
@@ -49,7 +49,6 @@ class TestWriteTfVars(unittest.TestCase):
                     }
             })
         with open(self.fake_tfvars_filename, "r") as tf_vars:
-            # print(tf_vars.read())
             self.assertEqual(
                 tf_vars.read(),
                 'test="true"\nciviform_server_environment_variables = {\n  "MY_VAR"="Is cool"\n  "FEATURE_ENABLED"="false"\n}\nstring_list=[\'test\', \'test\']\nint_list=[1, 2]\n'

--- a/cloud/shared/bin/lib/write_tfvars_test.py
+++ b/cloud/shared/bin/lib/write_tfvars_test.py
@@ -41,12 +41,18 @@ class TestWriteTfVars(unittest.TestCase):
                     {
                         "MY_VAR": "Is cool",
                         "FEATURE_ENABLED": "false"
+                    },
+                "terraform_list_variables":
+                    {
+                        "STRING_LIST": ["test", "test"],
+                        "INT_LIST": [1, 2]
                     }
             })
         with open(self.fake_tfvars_filename, "r") as tf_vars:
+            # print(tf_vars.read())
             self.assertEqual(
                 tf_vars.read(),
-                'test="true"\nciviform_server_environment_variables = {\n  "MY_VAR"="Is cool"\n  "FEATURE_ENABLED"="false"\n}\n'
+                'test="true"\nciviform_server_environment_variables = {\n  "MY_VAR"="Is cool"\n  "FEATURE_ENABLED"="false"\n}\nstring_list=[\'test\', \'test\']\nint_list=[1, 2]\n'
             )
 
 


### PR DESCRIPTION
### Description

Add support for list type, since we want to add a variable for private and public subnets, which will be a list of strings

Note: another solution of this is written in https://github.com/civiform/cloud-deploy-infra/pull/343/files

This is a follow up to https://github.com/civiform/cloud-deploy-infra/pull/337

If we don't do this, we get an error when we add `export EXTERNAL_VPC_PRIVATE_SUBNET_IDS=["test"]` to the config:

```
│ Error: Invalid value for input variable
│ 
│   on setup.auto.tfvars line 14:
│   14: external_vpc_private_subnet_ids="['test']"
│ 
│ The given value is not suitable for var.external_vpc_private_subnet_ids
│ declared at variables.tf:523,1-43: list of string required.
```

This will be used to support a list of public and private subnets from Charlotte (https://github.com/civiform/civiform/issues/7648) - see in progress PR [here](https://github.com/civiform/cloud-deploy-infra/compare/dkatz-subnet-list?expand=1)

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7750

