### PR TITLE
Only apply database changes immediately when doing a major upgrade

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -128,6 +128,12 @@ def _check_for_postgres_upgrade(config: ConfigLoader, aws: AwsCli):
                         exit(2)
                 config.add_config_value('ALLOW_POSTGRESQL_UPGRADE', 'true')
 
+            # We must force APPLY_DATABASE_CHANGES_IMMEDIATELY to true, since we are changing the database parameters along
+            # with the database itself, and we need to apply both changes at the same time. We can't wait for the next
+            # maintenance window.
+            config.add_config_value(
+                'APPLY_DATABASE_CHANGES_IMMEDIATELY', 'true')
+
             print(
                 f'{Color.CYAN}Proceeding with upgrade to PostgreSQL {config.get_config_var("POSTGRESQL_VERSION")}.{Color.END}'
             )

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -34,7 +34,7 @@ resource "aws_db_instance" "civiform" {
     Type = "Civiform Database"
   }
 
-  apply_immediately = true
+  apply_immediately = var.apply_database_changes_immediately
 
   # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
   snapshot_identifier             = var.postgres_restore_snapshot_identifier

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -422,5 +422,11 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
+  },
+  "APPLY_DATABASE_CHANGES_IMMEDIATELY": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -508,6 +508,12 @@ variable "postgresql_version" {
   default     = "16"
 }
 
+variable "apply_database_changes_immediately" {
+  type        = bool
+  description = "Apply database changes, such as a database version upgrade, during this deployment. When false, database changes will apply during the next maintenance window. This variable will be forced to 'true' when a major PostgreSQL version upgrade is needed."
+  default     = false
+}
+
 variable "external_vpc_database_subnet_group_name" {
   type        = string
   description = "The externally managed database subnet group name."


### PR DESCRIPTION
Because we had the 'apply_immediately' parameter on the aws_db_instance hard-coded to true, this meant that whenever there was a new postgres minor available in AWS, the deployment would force the database to upgrade to that minor during the deployment, incurring downtime. Since CEs would prefer to have that downtime happen during the maintenance window instead since this happens in off hours, this only forces the parameter to true during a major database upgrade, where we are also changing the database parameters and need to make both changes at the same time.

If a user wishes, they can set APPLY_DATABASE_CHANGES_IMMEDIATELY=true in their config to override this behavior.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/7715
