### PR TITLE
Look up AMI to use for dumpdb/restoredb

### DIFF
--- a/cloud/aws/modules/dbaccess/main.tf
+++ b/cloud/aws/modules/dbaccess/main.tf
@@ -55,8 +55,22 @@ resource "aws_key_pair" "dbaccess_key_pair" {
   }
 }
 
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical official
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
 resource "aws_instance" "dbaccess_host" {
-  ami             = var.host_ami
+  ami             = data.aws_ami.ubuntu.image_id
   instance_type   = var.host_type
   key_name        = aws_key_pair.dbaccess_key_pair.key_name
   security_groups = [aws_security_group.dbaccess_security_group.id]

--- a/cloud/aws/modules/dbaccess/variables.tf
+++ b/cloud/aws/modules/dbaccess/variables.tf
@@ -34,11 +34,6 @@ variable "public_subnet" {
   type        = string
   description = "ID of the public subnet to deploy the dbaccess instance in"
 }
-variable "host_ami" {
-  type        = string
-  description = "AMI ID to use for the dbaccess instance"
-  default     = "ami-080e1f13689e07408"
-}
 variable "host_type" {
   type        = string
   description = "Instance type to use for the dbaccess instance"


### PR DESCRIPTION
The AMI used as the default for the dbaccess image was only present in us-east-1, and each region has a different AMI for the same image. This looks up the latest AMI for Ubuntu 24.04 in whatever region you are running in and uses that rather than a hardcoded value.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/7714
