### PR TITLE
Default to not printing pgadmin/database credentials for pgadmin

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -5,7 +5,7 @@ from cloud.aws.templates.aws_oidc.bin import resources
 from cloud.aws.templates.aws_oidc.bin.aws_cli import AwsCli
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib.print import print
-from cloud.shared.bin.lib.color import Color
+from cloud.shared.bin.lib.color import red, yellow, cyan
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 
 
@@ -38,8 +38,9 @@ def _check_application_secret_length(config: ConfigLoader, aws: AwsCli):
         secret_length = aws.get_application_secret_length()
         if secret_length < 32:
             print(
-                f'{Color.RED}The application secret must be at least 32 characters in length, and ideally 64 characters. The current secret has a length of {secret_length}. See https://docs.civiform.us/it-manual/sre-playbook/initial-deployment/terraform-deploy-system#rotating-the-application-secret for details on how to regenerate the secret with a longer length.{Color.END}'
-            )
+                red(
+                    f'The application secret must be at least 32 characters in length, and ideally 64 characters. The current secret has a length of {secret_length}. See https://docs.civiform.us/it-manual/sre-playbook/initial-deployment/terraform-deploy-system#rotating-the-application-secret for details on how to regenerate the secret with a longer length.'
+                ))
             exit(1)
 
 
@@ -74,38 +75,44 @@ def _check_for_postgres_upgrade(config: ConfigLoader, aws: AwsCli):
         if major_to_apply != current_major:
             print(
                 textwrap.dedent(
-                    f'''
-                {Color.CYAN}This version of CiviForm contains an upgrade to PostgreSQL {major_to_apply}. Your install is currently using PostgreSQL version {current_version}.
+                    cyan(
+                        f'''
+                This version of CiviForm contains an upgrade to PostgreSQL {major_to_apply}. Your install is currently using PostgreSQL version {current_version}.
                 
                 The upgrade may take an extra 10-20 minutes to complete, during which time the CiviForm application will be unavailable. Before upgrading, ensure you have a backup of your database. You can do this by running bin/run and choosing the dumpdb command.
                 
-                Additionally, a snapshot will be performed just prior to the upgrade. The snapshot will have a name that starts with "preupgrade". You may also have a snapshot called "{config.app_prefix}-civiform-db-finalsnapshot".{Color.END}
-                '''))
+                Additionally, a snapshot will be performed just prior to the upgrade. The snapshot will have a name that starts with "preupgrade". You may also have a snapshot called "{config.app_prefix}-civiform-db-finalsnapshot".
+                ''')))
             if major_to_apply < current_major:
                 print(
-                    f'{Color.RED}Your current version of PostgreSQL appears to be newer than the version specified for this CiviForm release. Ensure you are using the correct version of the cloud-deploy-infra repo and POSTGRESQL_VERSION is unset or set appropriately.{Color.END}'
-                )
+                    red(
+                        'Your current version of PostgreSQL appears to be newer than the version specified for this CiviForm release. Ensure you are using the correct version of the cloud-deploy-infra repo and POSTGRESQL_VERSION is unset or set appropriately.'
+                    ))
                 exit(1)
             if major_to_apply != 16:
                 print(
-                    f'{Color.RED}Unsupported upgrade to PostgreSQL version {major_to_apply} specified for POSTGRESQL_VERSION. If this seems incorrect, contact a CiviForm maintainer.{Color.END}'
-                )
+                    red(
+                        f'Unsupported upgrade to PostgreSQL version {major_to_apply} specified for POSTGRESQL_VERSION. If this seems incorrect, contact a CiviForm maintainer.'
+                    ))
                 exit(1)
             if current_major == 12 and current_minor < 17:
                 print(
-                    f'{Color.RED}In order to upgrade to PostgreSQL {major_to_apply}, you must first upgrade to PostgreSQL 12.17 or a later PostgreSQL 12 minor version. You will need to perform this upgrade in the AWS RDS console before proceeding.{Color.END}'
-                )
+                    red(
+                        f'In order to upgrade to PostgreSQL {major_to_apply}, you must first upgrade to PostgreSQL 12.17 or a later PostgreSQL 12 minor version. You will need to perform this upgrade in the AWS RDS console before proceeding.'
+                    ))
                 exit(1)
             if current_version not in upgrade_path.keys():
                 print(
-                    f'{Color.YELLOW}This version of the CiviForm deployment tool has no information about your current PostgreSQL version of {current_version} and thus cannot choose the correct version to upgrade to. If you proceed, we will attempt to upgrade to the latest {major_to_apply}.x version, but this may not succeed. Check https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html to verify that this is a valid upgrade path.{Color.END}'
-                )
+                    yellow(
+                        f'This version of the CiviForm deployment tool has no information about your current PostgreSQL version of {current_version} and thus cannot choose the correct version to upgrade to. If you proceed, we will attempt to upgrade to the latest {major_to_apply}.x version, but this may not succeed. Check https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html to verify that this is a valid upgrade path.'
+                    ))
                 if os.getenv('SKIP_USER_INPUT'):
                     print('Proceeding since SKIP_USER_INPUT is set.')
                 else:
                     answer = input(
-                        f'{Color.YELLOW}Would you like to proceed with the upgrade? (y/N): {Color.END}'
-                    )
+                        yellow(
+                            'Would you like to proceed with the upgrade? (y/N): '
+                        ))
                     if answer.lower() not in ['y', 'yes']:
                         exit(1)
             else:
@@ -122,8 +129,9 @@ def _check_for_postgres_upgrade(config: ConfigLoader, aws: AwsCli):
                         'Proceeding with upgrade since SKIP_USER_INPUT is set.')
                 else:
                     answer = input(
-                        f'{Color.YELLOW}Would you like to proceed with the upgrade? (y/N): {Color.END}'
-                    )
+                        yellow(
+                            'Would you like to proceed with the upgrade? (y/N): '
+                        ))
                     if answer.lower() not in ['y', 'yes']:
                         exit(2)
                 config.add_config_value('ALLOW_POSTGRESQL_UPGRADE', 'true')
@@ -135,5 +143,6 @@ def _check_for_postgres_upgrade(config: ConfigLoader, aws: AwsCli):
                 'APPLY_DATABASE_CHANGES_IMMEDIATELY', 'true')
 
             print(
-                f'{Color.CYAN}Proceeding with upgrade to PostgreSQL {config.get_config_var("POSTGRESQL_VERSION")}.{Color.END}'
-            )
+                cyan(
+                    f'Proceeding with upgrade to PostgreSQL {config.get_config_var("POSTGRESQL_VERSION")}.'
+                ))

--- a/cloud/shared/bin/lib/color.py
+++ b/cloud/shared/bin/lib/color.py
@@ -1,10 +1,45 @@
-class Color:
-    BLACK = '\033[30m'
-    RED = '\033[31m'
-    GREEN = '\033[32m'
-    YELLOW = '\033[33m'
-    BLUE = '\033[34m'
-    MAGENTA = '\033[35m'
-    CYAN = '\033[36m'
-    WHITE = '\033[37m'
-    END = '\033[0m'
+BLACK = '\033[30m'
+RED = '\033[31m'
+GREEN = '\033[32m'
+YELLOW = '\033[33m'
+BLUE = '\033[34m'
+MAGENTA = '\033[35m'
+CYAN = '\033[36m'
+WHITE = '\033[37m'
+END = '\033[0m'
+
+
+def colorize(color, text):
+    return color + text + END
+
+
+def black(text):
+    return colorize(BLACK, text)
+
+
+def red(text):
+    return colorize(RED, text)
+
+
+def green(text):
+    return colorize(GREEN, text)
+
+
+def yellow(text):
+    return colorize(YELLOW, text)
+
+
+def blue(text):
+    return colorize(BLUE, text)
+
+
+def magenta(text):
+    return colorize(MAGENTA, text)
+
+
+def cyan(text):
+    return colorize(CYAN, text)
+
+
+def white(text):
+    return colorize(WHITE, text)

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -11,7 +11,7 @@ import urllib.request
 from typing import List
 from typing import Optional
 
-from cloud.shared.bin.lib.color import Color
+from cloud.shared.bin.lib.color import red, yellow
 from cloud.shared.bin.lib.config_parser import ConfigParser
 from cloud.shared.bin.lib.print import print
 from cloud.shared.bin.lib.write_tfvars import TfVarWriter
@@ -76,8 +76,8 @@ class ConfigLoader:
         if config_fields.get(
                 "ALLOW_ADMIN_WRITEABLE") and not os.getenv('SKIP_USER_INPUT'):
             msg = inspect.cleandoc(
-                f'''
-                {Color.YELLOW}
+                yellow(
+                    '''
                 ###########################################################################
                                                 WARNING                                                       
                 ###########################################################################
@@ -89,8 +89,7 @@ class ConfigLoader:
                 panel.
 
                 Would you like to continue with the deploy? [y/N] > 
-                {Color.END}
-                ''')
+                '''))
             answer = input(msg)
             if answer.lower() not in ['y', 'yes']:
                 exit(1)
@@ -313,8 +312,7 @@ class ConfigLoader:
                 # and are not required in the config
                 if variable.required and not is_admin_writeable:
                     validation_errors.append(
-                        f"{Color.RED}'{name}' is required but not set{Color.END}"
-                    )
+                        red(f"'{name}' is required but not set"))
                 continue
 
             # Throw an error if an admin writeable var is set in the deploy config
@@ -322,8 +320,9 @@ class ConfigLoader:
                 "ALLOW_ADMIN_WRITEABLE")
             if config_value is not None and disallow_admin_writeable:
                 validation_errors.append(
-                    f"{Color.RED}'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution).{Color.END}"
-                )
+                    red(
+                        f"'{name}' is editable via the admin settings panel and should not be set in the deploy config. Please remove it from your config file and try again. Set ALLOW_ADMIN_WRITEABLE=true in your config file to ignore this warning (use with caution)."
+                    ))
 
             # Variable types are 'string', 'int', 'bool', or 'index-list'.
             # Validation for 'index-list' is not implemented at this time because
@@ -332,15 +331,17 @@ class ConfigLoader:
                 if variable.values is not None:
                     if config_value not in variable.values:
                         validation_errors.append(
-                            f"{Color.RED}'{name}': '{config_value}' is not a valid value. Valid values are {variable.values}{Color.END}"
-                        )
+                            red(
+                                f"'{name}': '{config_value}' is not a valid value. Valid values are {variable.values}"
+                            ))
                         continue
 
                 if variable.regex is not None:
                     if re.match(variable.regex, config_value) == None:
                         validation_errors.append(
-                            f"{Color.RED}'{name}': '{config_value}' does not match validation regular expression '{variable.regex}'{Color.END}"
-                        )
+                            red(
+                                f"'{name}': '{config_value}' does not match validation regular expression '{variable.regex}'"
+                            ))
                         continue
 
             if variable.type == "int":
@@ -348,15 +349,15 @@ class ConfigLoader:
                     int(config_value)
                 except ValueError as e:
                     validation_errors.append(
-                        f"{Color.RED}'{name}' is required to be an integer: {e}{Color.END}"
-                    )
+                        red(f"'{name}' is required to be an integer: {e}"))
                     continue
 
             if variable.type == "bool":
                 if config_value not in ["true", "false"]:
                     validation_errors.append(
-                        f"{Color.RED}'{name}' is required to be either 'true' or 'false', got '{config_value}'{Color.END}"
-                    )
+                        red(
+                            f"'{name}' is required to be either 'true' or 'false', got '{config_value}'"
+                        ))
                     continue
 
         return validation_errors

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -9,7 +9,7 @@ from cloud.shared.bin.lib.setup_class_loader import get_config_specific_setup
 from cloud.shared.bin.lib.print import print
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin import destroy
-from cloud.shared.bin.lib.color import Color
+from cloud.shared.bin.lib.color import red, cyan
 """
 Setup.py sets up and runs the initial terraform deployment. It's broken into
 2 parts:
@@ -53,14 +53,18 @@ def run(config: ConfigLoader, params: List[str]):
     secret_length = config.get_config_var("RANDOM_PASSWORD_LENGTH")
     if not secret_length:
         print(
-            f'{Color.RED}RANDOM_PASSWORD_LENGTH is not set in the config file. Please add {Color.CYAN}export RANDOM_PASSWORD_LENGTH=64{Color.RED} to your config file and rerun this script.{Color.END}'
-        )
+            red(
+                'RANDOM_PASSWORD_LENGTH is not set in the config file. Please add '
+            ) + cyan('export RANDOM_PASSWORD_LENGTH=64') +
+            red(' to your config file and rerun this script.'))
         exit(1)
 
     if int(secret_length) < 32:
         print(
-            f'{Color.RED}RANDOM_PASSWORD_LENGTH is currently set to {secret_length}, but it must be 32 or greater. Please add {Color.CYAN}export RANDOM_PASSWORD_LENGTH=64{Color.RED} to your config file and rerun this script.{Color.END}'
-        )
+            red(
+                f'RANDOM_PASSWORD_LENGTH is currently set to {secret_length}, but it must be 32 or greater. Please add '
+            ) + cyan('export RANDOM_PASSWORD_LENGTH=64') +
+            red(' to your config file and rerun this script.'))
         exit(1)
 
     template_setup = get_config_specific_setup(config)


### PR DESCRIPTION
Because particularly the database password is sensitive, this now defaults to not printing the pgadmin and database credentials and giving the name of the secret instead so the user can look it up however they wish. But the user may also allow the script to print the credential if they are not worried about the security of printing it to the terminal.

This also refactors the Color lib to make it less cumbersome to use.

Tested with an existing deployment to verify it all works correctly, including the new Color refactor.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/7956
