### PR TITLE
Add support for terraform list variables with implied list type

### DIFF
--- a/cloud/shared/bin/lib/config_loader_test.py
+++ b/cloud/shared/bin/lib/config_loader_test.py
@@ -381,6 +381,14 @@ class TestConfigLoader(unittest.TestCase):
                     "tfvar": True,
                     "type": "string"
                 },
+            "FOO_2":
+                {
+                    "required": False,
+                    "secret": False,
+                    "tfvar": True,
+                    "type": "list",
+                    "list_type": "string"
+                },
         }
         config_loader._infra_variable_definitions = defs
 
@@ -405,12 +413,14 @@ class TestConfigLoader(unittest.TestCase):
                 mode=Mode.ADMIN_READABLE)
         config_loader._config_fields = config_fields = {
             "FOO_0": "item0, item1, item2",
-            "FOO_1": "normal string"
+            "FOO_1": "normal string",
+            "FOO_2": ["test1", "test2"]
         }
 
         terraform_vars = config_loader.get_terraform_variables()
-        self.assertEqual(2, len(terraform_vars))
+        self.assertEqual(3, len(terraform_vars))
         self.assertEqual(terraform_vars["FOO_1"], "normal string")
+        self.assertEqual(terraform_vars["FOO_2"], ["test1", "test2"])
 
         server_vars = terraform_vars[CIVIFORM_SERVER_VARIABLES_KEY]
         self.assertEqual(server_vars["FOO_1"], "normal string")

--- a/cloud/shared/bin/lib/write_tfvars.py
+++ b/cloud/shared/bin/lib/write_tfvars.py
@@ -27,4 +27,11 @@ class TfVarWriter:
                     continue
 
                 if definition is not None:
-                    tf_vars_file.write(f'{name.lower()}="{definition}"\n')
+                    try:
+                        parsed_definition = json.loads(definition)
+                    except json.JSONDecodeError as e:
+                        parsed_definition = definition
+                    if isinstance(parsed_definition, list):
+                        tf_vars_file.write(f'{name.lower()}={definition}\n')
+                    else:
+                        tf_vars_file.write(f'{name.lower()}="{definition}"\n')

--- a/cloud/shared/bin/lib/write_tfvars.py
+++ b/cloud/shared/bin/lib/write_tfvars.py
@@ -33,7 +33,5 @@ class TfVarWriter:
                         parsed_definition = json.loads(definition)
                     except json.JSONDecodeError as e:
                         parsed_definition = definition
-                    if isinstance(parsed_definition, list):
-                        tf_vars_file.write(f'{name.lower()}={definition}\n')
-                    else:
-                        tf_vars_file.write(f'{name.lower()}="{definition}"\n')
+                    formatted_value = definition if isinstance(parsed_definition, list) else f'"{definition}"'
+                    tf_vars_file.write(f'{name.lower()}={formatted_value}\n')

--- a/cloud/shared/bin/lib/write_tfvars.py
+++ b/cloud/shared/bin/lib/write_tfvars.py
@@ -6,6 +6,8 @@ If we want to store non string values here we will need to add in the variables
 and do a lil more advanced file writing
 """
 
+import json
+
 
 class TfVarWriter:
 

--- a/cloud/shared/bin/lib/write_tfvars.py
+++ b/cloud/shared/bin/lib/write_tfvars.py
@@ -33,5 +33,6 @@ class TfVarWriter:
                         parsed_definition = json.loads(definition)
                     except json.JSONDecodeError as e:
                         parsed_definition = definition
-                    formatted_value = definition if isinstance(parsed_definition, list) else f'"{definition}"'
+                    formatted_value = definition if isinstance(
+                        parsed_definition, list) else f'"{definition}"'
                     tf_vars_file.write(f'{name.lower()}={formatted_value}\n')


### PR DESCRIPTION
### Description

Add support for list type, since we want to add a variable for private and public subnets, which will be a list of strings

This is a simpler way of doing it than https://github.com/civiform/cloud-deploy-infra/pull/338, but this version does it based on implied type, instead of looking at the type inputed within the variables file.

This is a follow up to https://github.com/civiform/cloud-deploy-infra/pull/337

If we don't do this, we get an error when we add `export EXTERNAL_VPC_PRIVATE_SUBNET_IDS=["test"]` to the config:

```
│ Error: Invalid value for input variable
│ 
│   on setup.auto.tfvars line 14:
│   14: external_vpc_private_subnet_ids="['test']"
│ 
│ The given value is not suitable for var.external_vpc_private_subnet_ids
│ declared at variables.tf:523,1-43: list of string required.
```

This will be used to support a list of public and private subnets from Charlotte (https://github.com/civiform/civiform/issues/7648) - see in progress PR [here](https://github.com/civiform/cloud-deploy-infra/compare/dkatz-subnet-list?expand=1)

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7750
