### PR TITLE
Make load balancer internal when vpc is not managed through CiviForm

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -26,7 +26,7 @@ locals {
 resource "aws_lb" "civiform_lb" {
   name = substr("${local.name_prefix}-lb", 0, 31)
 
-  internal                         = local.enable_managed_vpc ? false : true
+  internal                         = var.lb_internal
   load_balancer_type               = "application"
   drop_invalid_header_fields       = false
   subnets                          = var.public_subnets

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -26,7 +26,7 @@ locals {
 resource "aws_lb" "civiform_lb" {
   name = substr("${local.name_prefix}-lb", 0, 31)
 
-  internal                         = false
+  internal                         = local.enable_managed_vpc ? false : true
   load_balancer_type               = "application"
   drop_invalid_header_fields       = false
   subnets                          = var.public_subnets

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -55,6 +55,11 @@ variable "container_name" {
   description = "Name of the running container"
 }
 
+variable "lb_internal" {
+  description = "Whether the load balancer should be internal"
+  default     = false
+}
+
 #------------------------------------------------------------------------------
 # AWS ECS SERVICE AUTOSCALING
 #------------------------------------------------------------------------------

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -333,6 +333,7 @@ module "ecs_fargate_service" {
   scale_target_max_capacity = var.ecs_scale_target_max_capacity
   scale_target_min_capacity = var.ecs_scale_target_min_capacity
   https_target_port         = var.port
+  lb_internal               = local.enable_managed_vpc ? false : true
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"


### PR DESCRIPTION
### Description

If we don't do this, we get an error:

```
│ Error: creating ELBv2 application Load Balancer (charlotte-vpc10-civiform-lb): InvalidSubnet: VPC vpc-0f18a363a62cc1675 has no internet gateway
│       status code: 400, request id: f09051a2-e2fe-4b4d-9bc5-c80ba8f2d009
│ 
│   with module.ecs_fargate_service.aws_lb.civiform_lb,
│   on ../../modules/ecs_fargate_service/[main.tf](http://main.tf/) line 26, in resource "aws_lb" "civiform_lb":
│   26: resource "aws_lb" "civiform_lb" {
```

This is needed for Charlotte's deployment. We could also decide to make this a separate variable from the vpc changes, or can do that in the future if they no longer should be tied together.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system`
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Instructions for manual testing

Tested by deploying in the charlotte test environment with the config from this [branch](https://github.com/civiform/civiform-staging-deploy/compare/main...clt-changes) and tested to ensure this didn't change anything in an existing environment

### Issue(s) this completes

https://github.com/civiform/civiform/issues/7648
