### PR TITLE
Ensure the tasks have access to the database to make connections if using non-terraform VPC

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/outputs.tf
+++ b/cloud/aws/modules/ecs_fargate_service/outputs.tf
@@ -8,11 +8,16 @@ output "aws_lb_civiform_lb_arn" {
 }
 
 output "aws_security_group_lb_access_sg_id" {
-  description = "The ID of the security group"
+  description = "The ID of the LB access security group"
   value       = aws_security_group.lb_access_sg.id
 }
 
+output "aws_security_group_ecs_tasks_access_sg_id" {
+  description = "The ID of the ECS tasks access security group"
+  value       = aws_security_group.ecs_tasks_sg.id
+}
+
 output "aws_ecs_service_name" {
-  description = "The service name of the aws ecs service."
+  description = "The name of the AWS ECS service"
   value       = aws_ecs_service.service.name
 }

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -139,6 +139,17 @@ resource "aws_security_group" "rds" {
       cidr_blocks = ["${ingress.value}/32"]
     }
   }
+
+  dynamic "ingress" {
+    for_each = local.enable_managed_vpc ? [] : [1]
+    # If the VPC is managed outside of terraform, we need to ensure that the tasks have access to the database to make connections
+    content {
+      from_port       = 5432
+      to_port         = 5432
+      protocol        = "tcp"
+      security_groups = [module.ecs_fargate_service.aws_security_group_ecs_tasks_access_sg_id]
+    }
+  }
 }
 
 module "pgadmin" {


### PR DESCRIPTION
### Description

If the VPC is managed outside of terraform, we need to ensure that the tasks have access to the database to make connections. 

This will set up an ingress if the VPC is managed outside of terraform. This was needed as part of the charlotte deployment - https://github.com/civiform/civiform/issues/7648

Here is what the change looks like in the UI - https://github.com/civiform/civiform/issues/7648#issuecomment-2189083230

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Instructions for manual testing

Tested by deploying in the charlotte test environment with the config from this [branch](https://github.com/civiform/civiform-staging-deploy/compare/main...clt-changes) and tested to ensure this didn't change anything in an existing environment

### Issue(s) this completes

https://github.com/civiform/civiform/issues/7648