### PR TITLE
Update the threshold for RDS_LOW_MEMORY_THRESHOLD

### DIFF
--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -175,7 +175,7 @@ variable "rds_create_low_memory_alarm" {
 variable "rds_low_memory_threshold" {
   type        = string
   description = "The threshold for the low freeable memory (in bytes) before the alarm gets triggered (if enabled)."
-  default     = "150000000" // ~150 MB
+  default     = "75000000" // ~75 MB
 }
 
 variable "rds_create_low_cpu_credit_alarm" {


### PR DESCRIPTION
### Description

This alarm keeps alerting for both Seattle and Arkansas, so we're lowering the default threshold (since the default instance type is micro). This is 5-10% of the RAM for the t3 micro instance type. 

### Release notes

The RDS low memory threshold was updated to be lower, since it has been falsely alerting on staging instances. If you'd like to change the value from the default, you can update the RDS_LOW_MEMORY_THRESHOLD variable.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 

