### PR TITLE
Add an option to enable ELB access logging

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -137,3 +137,9 @@ variable "default_certificate_arn" {
   type        = string
   default     = null
 }
+
+variable "lb_logging_enabled" {
+  description = "Whether to enable LB access logs."
+  type        = bool
+  default     = false
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -334,6 +334,7 @@ module "ecs_fargate_service" {
   scale_target_min_capacity = var.ecs_scale_target_min_capacity
   https_target_port         = var.port
   lb_internal               = local.enable_managed_vpc ? false : true
+  lb_logging_enabled        = var.lb_logging_enabled
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -430,5 +430,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "LB_LOGGING_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -537,3 +537,9 @@ variable "external_vpc_public_subnet_ids" {
   description = "The externally managed VPC's public subnet ID."
   default     = []
 }
+
+variable "lb_logging_enabled" {
+  type        = bool
+  description = "Whether to enable LB access logging."
+  default     = false
+}


### PR DESCRIPTION
### Description

Add an option to enable ELB access logging.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

- Deploy normally w/o the new setting
- Update `civiform_config.sh` and set `LB_LOGGING_ENABLED="true"`
- Redeploy and observe the access logging is enabled.

### Issue(s) this completes

Part of https://github.com/civiform/civiform/issues/6726