### PR TITLE
Remove dead feature flags from azure terraform templates

### DIFF
--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -56,11 +56,8 @@ module "app" {
   saml_keystore_storage_account_name   = module.saml_keystore.storage_account_name
   saml_keystore_storage_container_name = module.saml_keystore.storage_container_name
 
-  feature_flag_reporting_enabled       = var.feature_flag_reporting_enabled
-  feature_flag_status_tracking_enabled = var.feature_flag_status_tracking_enabled
-  civiform_api_keys_ban_global_subnet  = var.civiform_api_keys_ban_global_subnet
-  civiform_server_metrics_enabled      = var.civiform_server_metrics_enabled
-  feature_flag_overrides_enabled       = var.feature_flag_overrides_enabled
+  civiform_api_keys_ban_global_subnet = var.civiform_api_keys_ban_global_subnet
+  civiform_server_metrics_enabled     = var.civiform_server_metrics_enabled
 }
 
 module "custom_hostname" {

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -125,18 +125,6 @@ variable "saml_keystore_container_name" {
   default     = "saml-keystore"
 }
 
-variable "feature_flag_reporting_enabled" {
-  type        = bool
-  description = "Whether or not to enable the reporting feature"
-  default     = false
-}
-
-variable "feature_flag_status_tracking_enabled" {
-  type        = bool
-  description = "When set to true enable Status Tracking."
-  default     = false
-}
-
 variable "civiform_api_keys_ban_global_subnet" {
   type        = bool
   description = "Whether to allow 0.0.0.0/0 subnet for API key access."
@@ -146,11 +134,5 @@ variable "civiform_api_keys_ban_global_subnet" {
 variable "civiform_server_metrics_enabled" {
   type        = bool
   description = "Whether to enable exporting server metrics on the /metrics route."
-  default     = false
-}
-
-variable "feature_flag_overrides_enabled" {
-  type        = bool
-  description = "Whether feature flags can be override using /dev/feature/.../enable url."
   default     = false
 }


### PR DESCRIPTION
### Description

Remove obsolete feature flags from the Azure terraform templates

None of these exist in env-var-docs.json anymore so they are dead.

### Checklist

#### General

- [x] Assigned to a specific person or `civiform/deployment-system`