### PR TITLE
Add inbound rule for Charlotte deployment

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -321,13 +321,13 @@ resource "aws_security_group_rule" "ingress_through_http_and_https" {
 }
 
 resource "aws_security_group_rule" "ingress_with_custom_cidr" {
-  count                    = var.extra_inbound_rule_cidr != null ? 1 : 0
-  security_group_id        = aws_security_group.ecs_tasks_sg.id
-  type                     = "ingress"
-  from_port                = 9000
-  to_port                  = 9000
-  protocol                 = "tcp"
-  cidr_blocks              = [var.extra_inbound_rule_cidr]
+  count             = var.extra_inbound_rule_cidr != null ? 1 : 0
+  security_group_id = aws_security_group.ecs_tasks_sg.id
+  type              = "ingress"
+  from_port         = 9000
+  to_port           = 9000
+  protocol          = "tcp"
+  cidr_blocks       = [var.extra_inbound_rule_cidr]
 }
 
 moved {

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -320,6 +320,16 @@ resource "aws_security_group_rule" "ingress_through_http_and_https" {
   source_security_group_id = aws_security_group.lb_access_sg.id
 }
 
+resource "aws_security_group_rule" "ingress_with_custom_cidr" {
+  count                    = var.extra_inbound_rule_cidr != null ? 1 : 0
+  security_group_id        = aws_security_group.ecs_tasks_sg.id
+  type                     = "ingress"
+  from_port                = 9000
+  to_port                  = 9000
+  protocol                 = "tcp"
+  cidr_blocks              = [var.extra_inbound_rule_cidr]
+}
+
 moved {
   from = aws_security_group_rule.ingress_through_http_and_https["9000"]
   to   = aws_security_group_rule.ingress_through_http_and_https

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -143,3 +143,9 @@ variable "lb_logging_enabled" {
   type        = bool
   default     = false
 }
+
+variable "extra_inbound_rule_cidr" {
+  description = "(Optional) The CIDR block of the inbound rule to be added. Required if using a custom VPC"
+  type        = string
+  default     = null
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -335,6 +335,7 @@ module "ecs_fargate_service" {
   https_target_port         = var.port
   lb_internal               = local.enable_managed_vpc ? false : true
   lb_logging_enabled        = var.lb_logging_enabled
+  extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -436,5 +436,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "EXTRA_INBOUND_RULE_CIDR": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -543,3 +543,9 @@ variable "lb_logging_enabled" {
   description = "Whether to enable LB access logging."
   default     = false
 }
+
+variable "extra_inbound_rule_cidr" {
+  description = "(Optional) The CIDR block of the inbound rule to be added. Required if using a custom VPC"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Description

Charlotte's deployment with a custom VPC was successful, but their load balancers weren't able to make requests. Adding the inbound rule manually fixed this, so adding to the terraform config as well.

This is set up as a variable and if it isn't specified it won't be created.

Tested by setting up without the rule then added it through terraform and saw it represented in the same way that charlotte has it:
<img width="842" alt="Screenshot 2024-08-19 at 4 43 57 PM" src="https://github.com/user-attachments/assets/3ca1d384-a035-4dab-99a9-5070f95e617d">


### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7648
