### PR TITLE
Generate url safe password for postgres database

### DIFF
--- a/cloud/azure/bin/lib/key_vault.sh
+++ b/cloud/azure/bin/lib/key_vault.sh
@@ -92,9 +92,14 @@ function key_vault::add_generated_secrets() {
   shift
   for key in "$@"; do
     echo "Generating secret: ${key}"
+    local USECHARSET=$CHARSET
+    if [[ "${key}" == "postgres-password" ]]; then
+      echo "Using url safe charset"
+      USECHARSET=$URL_SAFE
+    fi 
     local SECRET_VALUE="$(head /dev/urandom \
-      | LC_CTYPE=ALL tr -dc "${CHARSET}" \
-      | LC_CTYPE=ALL cut -c -40)"
+    | LC_CTYPE=ALL tr -dc "${USECHARSET}" \
+    | LC_CTYPE=ALL cut -c -40)"
     echo "Setting secret: ${key}"
     key_vault::add_secret "${VAULT_NAME}" "${key}" "${SECRET_VALUE}"
   done

--- a/cloud/azure/bin/lib/key_vault.sh
+++ b/cloud/azure/bin/lib/key_vault.sh
@@ -96,10 +96,10 @@ function key_vault::add_generated_secrets() {
     if [[ "${key}" == "postgres-password" ]]; then
       echo "Using url safe charset"
       USECHARSET=$URL_SAFE
-    fi 
+    fi
     local SECRET_VALUE="$(head /dev/urandom \
-    | LC_CTYPE=ALL tr -dc "${USECHARSET}" \
-    | LC_CTYPE=ALL cut -c -40)"
+      | LC_CTYPE=ALL tr -dc "${USECHARSET}" \
+      | LC_CTYPE=ALL cut -c -40)"
     echo "Setting secret: ${key}"
     key_vault::add_secret "${VAULT_NAME}" "${key}" "${SECRET_VALUE}"
   done

--- a/cloud/azure/bin/lib/key_vault.sh
+++ b/cloud/azure/bin/lib/key_vault.sh
@@ -4,6 +4,7 @@
 # use when generating a secret value
 readonly CHARSET='A-Za-z0-9!#$%&()*+,-./:;<=>?@[\]^_{|}~'
 readonly KEY_VAULT_SECRETS_OFFICER_GUID="b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
+readonly URL_SAFE='A-Za-z0-9-._~'
 
 #######################################
 # Create key vault


### PR DESCRIPTION
### Description

Use url safe charset for postgres password. Section 2.3 of https://www.ietf.org/rfc/rfc3986.txt states that url safe is `Characters that are allowed in a URI, but do not have a reserved purpose, are called unreserved. These include uppercase and lowercase letters, decimal digits, hyphen, period, underscore, and tilde.`

### Checklist

#### General

- [x ] Added the correct label
- [ x] Assigned to a specific person or `civiform/deployment-system` 
- [x ] Created tests which fail without the change (if possible)
- [x ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ x] Extended the README / documentation, if necessary

