### PR TITLE
Fix pgadmin for deployment with vpc

### DIFF
--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -166,7 +166,7 @@ module "pgadmin" {
   cidr_allowlist  = var.pgadmin_cidr_allowlist
 
   ecs_cluster_arn = module.ecs_cluster.aws_ecs_cluster_cluster_arn
-  subnet_ids      = local.vpc_private_subnets
+  subnet_ids      = local.vpc_private_subnet_ids
 
   db_sg_id               = aws_security_group.rds.id
   db_address             = data.aws_db_instance.civiform.address


### PR DESCRIPTION
### Description

We were getting an error when running pgadmin:

```
╷
│ Error: Invalid value for input variable
│ 
│   on main.tf line 169, in module "pgadmin":
│  169:   subnet_ids      = local.vpc_private_subnets
│ 
│ The given value is not suitable for module.pgadmin[0].var.subnet_ids
│ declared at ../../modules/pgadmin/variables.tf:47,1-22: element 0: string
│ required.
```

By pointing at the ID variable instead, we are successfully able to create pgadmin resources. Note: this doesn't change anything for non-vpc enabled deployments, since _private_subnets and _private_subnet_ids point to the same thing for those https://github.com/civiform/cloud-deploy-infra/blob/d5c99d3a9f34c32b9626089e243a7f86950ecb7e/cloud/aws/templates/aws_oidc/vpc.tf#L19

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/8412
