### PR TITLE
Update e2e test schedule

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,8 +1,8 @@
 name: e2e-test
 on:
-  # Runs every day at 3:12 UTC.
+  # Runs every day at 3:11 UTC.
   schedule:
-    - cron: "12 3 * * *"
+    - cron: "11 3 * * *"
   # Allow manually triggered runs.
   workflow_dispatch:
 


### PR DESCRIPTION
Per https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule we have to actually make a commit here now that Avritt has left in order to keep this going and have the workflow run as this user.