### PR TITLE
Change role profile of the keyvault to "Administrator" from "User" 

### DIFF
--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -8,13 +8,13 @@ resource "azurerm_role_assignment" "storage_blob_delegator" {
 
 resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Secrets User"
+  role_definition_name = "Key Vault Secrets Administrator"
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
 }
 
 resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Secrets User for staging deployment "
+  role_definition_name = "Key Vault Secrets Administrator"
   principal_id         = "f552a386-fd60-40bf-93a7-57c441bb0c99"
 }
 

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -6,10 +6,16 @@ resource "azurerm_role_assignment" "storage_blob_delegator" {
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
 }
 
-resource "azurerm_role_assignment" "key_vault_secrets_user" {
+resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
+}
+
+resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
+  scope                = data.azurerm_key_vault.civiform_key_vault.id
+  role_definition_name = "Key Vault Secrets User for staging deployment "
+  principal_id         = "f552a386-fd60-40bf-93a7-57c441bb0c99"
 }
 
 resource "azurerm_role_assignment" "storage_blob_data_contributor" {

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -12,7 +12,7 @@ resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
 }
 
-resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
+resource "azurerm_role_assignment" "key_vault_secrets_key_vault_reference_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
   role_definition_name = "Key Vault Administrator"
   principal_id         = azurerm_linux_web_app.civiform_app.key_vault_reference_identity_id

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -8,13 +8,13 @@ resource "azurerm_role_assignment" "storage_blob_delegator" {
 
 resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Administrator	"
+  role_definition_name = "Key Vault Administrator"
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
 }
 
 resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Administrator	"
+  role_definition_name = "Key Vault Administrator"
   principal_id         = "f552a386-fd60-40bf-93a7-57c441bb0c99"
 }
 

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -12,12 +12,6 @@ resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
 }
 
-resource "azurerm_role_assignment" "key_vault_secrets_key_vault_reference_user" {
-  scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Administrator"
-  principal_id         = azurerm_linux_web_app.civiform_app.key_vault_reference_identity_id
-}
-
 resource "azurerm_role_assignment" "storage_blob_data_contributor" {
   scope                = azurerm_storage_account.files_storage_account.id
   role_definition_name = "Storage Blob Data Contributor"

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -8,13 +8,13 @@ resource "azurerm_role_assignment" "storage_blob_delegator" {
 
 resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Secrets Administrator"
+  role_definition_name = "Key Vault Administrator	"
   principal_id         = azurerm_linux_web_app.civiform_app.identity.0.principal_id
 }
 
 resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
-  role_definition_name = "Key Vault Secrets Administrator"
+  role_definition_name = "Key Vault Administrator	"
   principal_id         = "f552a386-fd60-40bf-93a7-57c441bb0c99"
 }
 

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -15,7 +15,7 @@ resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
 resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
   role_definition_name = "Key Vault Administrator"
-  principal_id         = "f552a386-fd60-40bf-93a7-57c441bb0c99"
+  principal_id         = azurerm_linux_web_app.civiform_app.identity.0.key_vault_reference_identity_id
 }
 
 resource "azurerm_role_assignment" "storage_blob_data_contributor" {

--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -15,7 +15,7 @@ resource "azurerm_role_assignment" "key_vault_secrets_principal_user" {
 resource "azurerm_role_assignment" "key_vault_secrets_staging_user" {
   scope                = data.azurerm_key_vault.civiform_key_vault.id
   role_definition_name = "Key Vault Administrator"
-  principal_id         = azurerm_linux_web_app.civiform_app.identity.0.key_vault_reference_identity_id
+  principal_id         = azurerm_linux_web_app.civiform_app.key_vault_reference_identity_id
 }
 
 resource "azurerm_role_assignment" "storage_blob_data_contributor" {


### PR DESCRIPTION
### Description

"Users" cannot read / write to the keyvault, which worked okay locally I think because there were other permissions in play from using az login but the deployment yaml runs the terraform process using the service-principal id of the app registration, which requires Administrator access  in order to perform the required keyvault actions during deployment. 

### Checklist

#### General

- [ x] Added the correct label
- [ x] Assigned to a specific person or `civiform/deployment-system` 
- [ x] Created tests which fail without the change (if possible)
- [ x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

