### PR TITLE
Add knobs to adjust healcheck parameters.

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -164,8 +164,8 @@ resource "aws_lb_target_group" "lb_https_tgs" {
     path                = "/playIndex"
     protocol            = "HTTP"
     timeout             = var.healthcheck.timeout
-    healthy_threshold   = var.healthcheck.healthy_threshold
-    unhealthy_threshold = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = var.healthcheck.unhealthy_threshold
     matcher             = "200"
   }
 

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -160,11 +160,11 @@ resource "aws_lb_target_group" "lb_https_tgs" {
 
   health_check {
     enabled             = true
-    interval            = 20
+    interval            = var.healthcheck.interval
     path                = "/playIndex"
     protocol            = "HTTP"
-    timeout             = 15
-    healthy_threshold   = 2
+    timeout             = var.healthcheck.timeout
+    healthy_threshold   = var.healthcheck.healthy_threshold
     unhealthy_threshold = 10
     matcher             = "200"
   }

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -153,8 +153,8 @@ variable "extra_inbound_rule_cidr" {
 variable "healthcheck" {
   description = "The healthcheck parameters for the ALB. See also https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#health_check"
   type = object({
-    interval            = optional(number, 10)
-    timeout             = optional(number, 30)
+    interval            = optional(number, 20)
+    timeout             = optional(number, 15)
     unhealthy_threshold = optional(number, 10)
   })
 }

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -149,3 +149,12 @@ variable "extra_inbound_rule_cidr" {
   type        = string
   default     = null
 }
+
+variable "healthcheck" {
+  description = "The healthcheck parameters for the ALB. See also https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#health_check"
+  type = object({
+    interval            = optional(number, 10)
+    timeout             = optional(number, 30)
+    unhealthy_threshold = optional(number, 10)
+  })
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -110,10 +110,10 @@ module "civiform_server_container_def" {
 
   healthcheck = {
     command     = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/playIndex --output-document - > /dev/null 2>&1"]
-    interval    = var.healthcheck_interval
-    timeout     = var.healthcheck_timeout
-    retries     = var.healthcheck_retries
-    startPeriod = var.healthcheck_startperiod
+    interval    = var.container_healthcheck_interval
+    timeout     = var.container_healthcheck_timeout
+    retries     = var.container_healthcheck_retries
+    startPeriod = var.container_healthcheck_startperiod
   }
 
   log_configuration = {
@@ -338,9 +338,9 @@ module "ecs_fargate_service" {
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
 
   healthcheck = {
-    interval            = var.healthcheck_interval
-    timeout             = var.healthcheck_timeout
-    unhealthy_threshold = var.healthcheck_retries
+    interval            = var.lb_healthcheck_interval
+    timeout             = var.lb_healthcheck_timeout
+    unhealthy_threshold = var.lb_healthcheck_unhealthy_threshold
   }
 
   tags = {

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -110,10 +110,10 @@ module "civiform_server_container_def" {
 
   healthcheck = {
     command     = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/playIndex --output-document - > /dev/null 2>&1"]
-    interval    = 10
-    timeout     = 30
-    retries     = 5
-    startPeriod = 10
+    interval    = var.healthcheck_interval
+    timeout     = var.healthcheck_timeout
+    retries     = var.healthcheck_retries
+    startPeriod = var.healthcheck_startperiod
   }
 
   log_configuration = {
@@ -336,6 +336,12 @@ module "ecs_fargate_service" {
   lb_internal               = local.enable_managed_vpc ? false : true
   lb_logging_enabled        = var.lb_logging_enabled
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
+
+  healthcheck = {
+    interval            = var.healthcheck_interval
+    timeout             = var.healthcheck_timeout
+    unhealthy_threshold = var.healthcheck_retries
+  }
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -443,25 +443,43 @@
     "tfvar": true,
     "type": "string"
   },
-  "HEALTHCHECK_INTERVAL": {
+  "CONTAINER_HEALTHCHECK_INTERVAL": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "number"
   },
-  "HEALTHCHECK_TIMEOUT": {
+  "CONTAINER_HEALTHCHECK_TIMEOUT": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "number"
   },
-  "HEALTHCHECK_RETRIES": {
+  "CONTAINER_HEALTHCHECK_RETRIES": {
     "required": false,
     "secret": false,
     "tfvar": true,
     "type": "number"
   },
-  "HEALTHCHECK_STARTPERIOD": {
+  "CONTAINER_HEALTHCHECK_STARTPERIOD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
+  "LB_HEALTHCHECK_INTERVAL": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
+  "LB_HEALTHCHECK_TIMEOUT": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
+  "LB_HEALTHCHECK_UNHEALTHY_THRESHOLD": {
     "required": false,
     "secret": false,
     "tfvar": true,

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -442,5 +442,29 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
+  },
+  "HEALTHCHECK_INTERVAL": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
+  "HEALTHCHECK_TIMEOUT": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
+  "HEALTHCHECK_RETRIES": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
+  },
+  "HEALTHCHECK_STARTPERIOD": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -447,42 +447,42 @@
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   },
   "CONTAINER_HEALTHCHECK_TIMEOUT": {
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   },
   "CONTAINER_HEALTHCHECK_RETRIES": {
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   },
   "CONTAINER_HEALTHCHECK_STARTPERIOD": {
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   },
   "LB_HEALTHCHECK_INTERVAL": {
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   },
   "LB_HEALTHCHECK_TIMEOUT": {
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   },
   "LB_HEALTHCHECK_UNHEALTHY_THRESHOLD": {
     "required": false,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -549,3 +549,27 @@ variable "extra_inbound_rule_cidr" {
   type        = string
   default     = null
 }
+
+variable "healthcheck_interval" {
+  type        = number
+  description = "Health check interval. Note this value is used by both ECS/ALB health check."
+  default     = 10
+}
+
+variable "healthcheck_timeout" {
+  type        = number
+  description = "Health check timeout. Note this value is used by both ECS/ALB health  check."
+  default     = 30
+}
+
+variable "healthcheck_retries" {
+  type        = number
+  description = "# of health check retries before marking it unhealthy. Note this is the `retries` for ECS (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#API_HealthCheck_Contents) and `unhealthy_threshold` for ALB (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#unhealthy_thresholdhttps://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#unhealthy_threshold)"
+  default     = 10
+}
+
+variable "healthcheck_startperiod" {
+  type        = number
+  description = "The grace period before considering the ECS container as healthy."
+  default     = 10
+}

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -550,26 +550,44 @@ variable "extra_inbound_rule_cidr" {
   default     = null
 }
 
-variable "healthcheck_interval" {
+variable "container_healthcheck_interval" {
   type        = number
-  description = "Health check interval. Note this value is used by both ECS/ALB health check."
+  description = "ECS container health check interval."
   default     = 10
 }
 
-variable "healthcheck_timeout" {
+variable "container_healthcheck_timeout" {
   type        = number
-  description = "Health check timeout. Note this value is used by both ECS/ALB health  check."
+  description = "ECS container health check timeout."
   default     = 30
 }
 
-variable "healthcheck_retries" {
+variable "container_healthcheck_retries" {
   type        = number
-  description = "# of health check retries before marking it unhealthy. Note this is the `retries` for ECS (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#API_HealthCheck_Contents) and `unhealthy_threshold` for ALB (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#unhealthy_thresholdhttps://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#unhealthy_threshold)"
+  description = "# of health check retries before marking it unhealthy. https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#API_HealthCheck_Contents"
   default     = 5
 }
 
-variable "healthcheck_startperiod" {
+variable "container_healthcheck_startperiod" {
   type        = number
   description = "The grace period before considering the ECS container as healthy."
+  default     = 10
+}
+
+variable "lb_healthcheck_interval" {
+  type        = number
+  description = "ECS container health check interval."
+  default     = 20
+}
+
+variable "lb_healthcheck_timeout" {
+  type        = number
+  description = "ECS container health check timeout."
+  default     = 15
+}
+
+variable "lb_healthcheck_unhealthy_threshold" {
+  type        = number
+  description = "# of health check retries before marking it unhealthy. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#health_check"
   default     = 10
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -553,19 +553,19 @@ variable "extra_inbound_rule_cidr" {
 variable "healthcheck_interval" {
   type        = number
   description = "Health check interval. Note this value is used by both ECS/ALB health check."
-  default     = 15
+  default     = 10
 }
 
 variable "healthcheck_timeout" {
   type        = number
   description = "Health check timeout. Note this value is used by both ECS/ALB health  check."
-  default     = 10 
+  default     = 30
 }
 
 variable "healthcheck_retries" {
   type        = number
   description = "# of health check retries before marking it unhealthy. Note this is the `retries` for ECS (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#API_HealthCheck_Contents) and `unhealthy_threshold` for ALB (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#unhealthy_thresholdhttps://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#unhealthy_threshold)"
-  default     = 10
+  default     = 5
 }
 
 variable "healthcheck_startperiod" {

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -553,13 +553,13 @@ variable "extra_inbound_rule_cidr" {
 variable "healthcheck_interval" {
   type        = number
   description = "Health check interval. Note this value is used by both ECS/ALB health check."
-  default     = 10
+  default     = 15
 }
 
 variable "healthcheck_timeout" {
   type        = number
   description = "Health check timeout. Note this value is used by both ECS/ALB health  check."
-  default     = 30
+  default     = 10 
 }
 
 variable "healthcheck_retries" {


### PR DESCRIPTION
### Description

Allow customizing the healthcheck parameters.

Note I added effectively two sets of interval/timeout/retries. It looks like we can't use the same set of values on both ALB and ECS, because ECS allow timeout>interval, while ALB does not allow it.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

Ran `bin/deploy`.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7698