### PR TITLE
Update to use ekristen aws-nuke

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -40,9 +40,9 @@ jobs:
       - id: get-nuke
         name: Get aws-nuke
         run: |
-          wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz -O aws-nuke-v2.25.0-linux-amd64.tar.gz
-          tar -xzf aws-nuke-v2.25.0-linux-amd64.tar.gz
-          sudo mv aws-nuke-v2.25.0-linux-amd64 /aws-nuke
+          wget https://github.com/ekristen/aws-nuke/releases/download/v3.17.3/aws-nuke-v3.17.3-linux-amd64.tar.gz -O aws-nuke-v3.17.3-linux-amd64.tar.gz
+          tar -xzf aws-nuke-v3.17.3-linux-amd64.tar.gz
+          sudo mv aws-nuke-v3.17.3-linux-amd64 /aws-nuke
           sudo chmod u+x /aws-nuke
 
       - id: get-aws-creds
@@ -54,7 +54,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Pre nuke
-        run: /aws-nuke --config $GITHUB_WORKSPACE/cloud-deploy-infra/e2e-test/nuke.yaml --no-dry-run --force --force-sleep=3
+        run: /aws-nuke run --config $GITHUB_WORKSPACE/cloud-deploy-infra/e2e-test/nuke.yaml --no-dry-run --force --force-sleep=3
 
       - name: Run bin/setup
         run: |
@@ -73,7 +73,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: /aws-nuke --config $GITHUB_WORKSPACE/cloud-deploy-infra/e2e-test/nuke.yaml --no-dry-run --force --force-sleep=3
+          command: /aws-nuke run --config $GITHUB_WORKSPACE/cloud-deploy-infra/e2e-test/nuke.yaml --no-dry-run --force --force-sleep=3
       - name: Notify Slack Complete
         if: always()
         uses: slackapi/slack-github-action@v1

--- a/e2e-test/nuke.yaml
+++ b/e2e-test/nuke.yaml
@@ -2,13 +2,39 @@ regions:
   - us-east-1
   - global
 
-account-blocklist:
+blocklist:
   - "664198874744"
   - "305584670637" 
   - "496466114051"
   - "559421412203"
   - "859704899281"
   - "098472360576"
+
+# A lot of these are ones that aws-nuke can't read anyway, either because
+# the service is no longer supported or isn't enabled for our accounts.
+# Excluding them saves time when aws-nuke is doing its initial query and
+# prevents errors that are not really errors from showing up.
+resource-types:
+  excludes:
+    - AppStreamImage
+    - CloudSearchDomain
+    - CodeStarProject
+    - ElasticacheCacheParameterGroup
+    - FMSNotificationChannel
+    - FMSPolicy
+    - MachineLearningBranchPrediction
+    - MachineLearningDataSource
+    - MachineLearningEvaluation
+    - MachineLearningMLModel
+    - OpsWorksApp
+    - OpsWorksCMBackup
+    - OpsWorksCMServer
+    - OpsWorksCMServerState
+    - OpsWorksInstance
+    - OpsWorksLayer
+    - OpsWorksUserProfile
+    - OSPackage
+    - ResourceExplorer2Index
 
 accounts:
   "296877675213": # civiform-deploy-e2e-tests AWS account.
@@ -24,8 +50,6 @@ accounts:
         - "OrganizationAccountAccessRole"
         - "e2e-test-runner"
         - property: "Name"
-          regex: "^AWSReservedSSO_.+$"
-        - property: "Name"
           type: glob
           value: "*-deploy-action"
       IAMRolePolicy:
@@ -35,20 +59,11 @@ accounts:
         - "OrganizationAccountAccessRole -> AdministratorAccess"
         - "e2e-test-runner -> AdministratorAccess"
         - property: "RoleName"
-          regex: "^AWSReservedSSO_.+$"
-        - property: "RoleName"
           type: glob
           value: "*-deploy-action"
       IAMSAMLProvider:
         - type: glob
           value: "arn:aws:iam::*:saml-provider/AWSSSO_*"
-      OpsWorksUserProfile:
-        - type: glob
-          value: "arn:aws:sts::*:assumed-role/OrganizationAccountAccessRole/*"
-      OSPackage:
-        - property: "PackageName"
-          type: regex
-          value: "^(analysis-\\w+|amazon-personalized-ranking)*"
       IAMUser:
         - 'e2e-test-runner'
       IAMUserAccessKey:


### PR DESCRIPTION
The original aws-nuke has been officially deprecated in favor of ekristen's fork. This updates the action to use this binary, and also updates the config file for use with this new binary.