### PR TITLE
Update azurerm version to 4.1.0 and remove outdated dependencies 

### DIFF
--- a/cloud/azure/modules/app/file-storage.tf
+++ b/cloud/azure/modules/app/file-storage.tf
@@ -1,10 +1,9 @@
 resource "azurerm_subnet" "storage_subnet" {
-  name                                           = "storage-subnet"
-  resource_group_name                            = data.azurerm_resource_group.rg.name
-  virtual_network_name                           = azurerm_virtual_network.civiform_vnet.name
-  address_prefixes                               = ["10.0.8.0/24"]
-  service_endpoints                              = ["Microsoft.Storage"]
-  enforce_private_link_endpoint_network_policies = true
+  name                 = "storage-subnet"
+  resource_group_name  = data.azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.civiform_vnet.name
+  address_prefixes     = ["10.0.8.0/24"]
+  service_endpoints    = ["Microsoft.Storage"]
 }
 
 resource "azurerm_storage_account" "files_storage_account" {
@@ -26,9 +25,9 @@ resource "azurerm_storage_container" "files_container" {
 }
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "blob_storage_backup_policy" {
-  name               = "storage-backup-policy"
-  vault_id           = azurerm_data_protection_backup_vault.backup_vault.id
-  retention_duration = "P30D"
+  name                                   = "storage-backup-policy"
+  vault_id                               = azurerm_data_protection_backup_vault.backup_vault.id
+  operational_default_retention_duration = "P30D"
 }
 
 resource "azurerm_data_protection_backup_instance_blob_storage" "blob_storage_backup_instance" {

--- a/cloud/azure/modules/app/logs.tf
+++ b/cloud/azure/modules/app/logs.tf
@@ -11,67 +11,42 @@ resource "azurerm_monitor_diagnostic_setting" "app_service_log_analytics" {
   target_resource_id         = azurerm_linux_web_app.civiform_app.id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.civiform_logs.id
 
-  log {
+  enabled_log {
     category = "AppServiceAppLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
-  log {
+  enabled_log {
     category = "AppServiceConsoleLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
-  log {
+  enabled_log {
     category = "AppServiceHTTPLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
-  log {
+  enabled_log {
     category = "AppServiceAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   # due to a bug in terraform include these even though they are not enabled
-  log {
-    category = "AppServiceIPSecAuditLogs"
-    enabled  = false
+  # enabled_log {
+  #   category = "AppServiceIPSecAuditLogs"
+  #   enabled  = false
 
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
-  }
-  log {
-    category = "AppServicePlatformLogs"
-    enabled  = false
+  #   retention_policy {
+  #     days    = 0
+  #     enabled = false
+  #   }
+  # }
+  # enabled_log {
+  #   category = "AppServicePlatformLogs"
+  #   enabled  = false
 
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
-  }
+  #   retention_policy {
+  #     days    = 0
+  #     enabled = false
+  #   }
+  # }
 }

--- a/cloud/azure/modules/app/logs.tf
+++ b/cloud/azure/modules/app/logs.tf
@@ -29,24 +29,4 @@ resource "azurerm_monitor_diagnostic_setting" "app_service_log_analytics" {
   metric {
     category = "AllMetrics"
   }
-
-  # due to a bug in terraform include these even though they are not enabled
-  # enabled_log {
-  #   category = "AppServiceIPSecAuditLogs"
-  #   enabled  = false
-
-  #   retention_policy {
-  #     days    = 0
-  #     enabled = false
-  #   }
-  # }
-  # enabled_log {
-  #   category = "AppServicePlatformLogs"
-  #   enabled  = false
-
-  #   retention_policy {
-  #     days    = 0
-  #     enabled = false
-  #   }
-  # }
 }

--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azurerm = {
       source  = "azurerm"
-      version = "3.116.0"
+      version = "4.1.0"
     }
     random = {}
   }


### PR DESCRIPTION
### Description

- change `retention_duration` to use new name `operational_default_retention_duration` 
- `enforce_private_link_endpoint_network_policies` can be safely removed because private link is not currently set up 
- retention_policy can be safely removed due to [this stackoverflow comment](https://stackoverflow.com/questions/77717130/retention-policy-terraform-is-deprecated-inside-azurerm-monitor-diagnostic-setti) stating that `enabled_log` blocks use the retention policy set in the `azurerm_log_analytics_workspace` resource. 

### Checklist

#### General

- [ x] Added the correct label
- [x ] Assigned to a specific person or `civiform/deployment-system` 
- [ x] Created tests which fail without the change (if possible)
- [ x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

