### PR TITLE
Minor v4.1.0 azurerm bugfixes

### DIFF
--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -18,7 +18,7 @@ locals {
   app_settings = merge({
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     PORT                                = 9000
-    
+
     DB_USERNAME          = "${azurerm_postgresql_flexible_server.civiform.administrator_login}@${azurerm_postgresql_flexible_server.civiform.name}"
     DB_PASSWORD          = data.azurerm_key_vault_secret.postgres_password.value
     DB_JDBC_STRING       = "jdbc:postgresql://${azurerm_postgresql_flexible_server.civiform.name}.postgres.database.azure.com:5432/postgres?user=${azurerm_postgresql_flexible_server.civiform.administrator_login}&password=${azurerm_postgresql_flexible_server.civiform.administrator_password}&sslmode=require"

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -18,8 +18,10 @@ locals {
   app_settings = merge({
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     PORT                                = 9000
-
-    DOCKER_REGISTRY_SERVER_URL = "https://index.docker.io"
+    
+    application_stack = {
+      DOCKER_REGISTRY_SERVER_URL = "https://index.docker.io"
+    }
 
     DB_USERNAME          = "${azurerm_postgresql_flexible_server.civiform.administrator_login}@${azurerm_postgresql_flexible_server.civiform.name}"
     DB_PASSWORD          = data.azurerm_key_vault_secret.postgres_password.value

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -19,10 +19,6 @@ locals {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     PORT                                = 9000
     
-    application_stack = {
-      DOCKER_REGISTRY_SERVER_URL = "https://index.docker.io"
-    }
-
     DB_USERNAME          = "${azurerm_postgresql_flexible_server.civiform.administrator_login}@${azurerm_postgresql_flexible_server.civiform.name}"
     DB_PASSWORD          = data.azurerm_key_vault_secret.postgres_password.value
     DB_JDBC_STRING       = "jdbc:postgresql://${azurerm_postgresql_flexible_server.civiform.name}.postgres.database.azure.com:5432/postgres?user=${azurerm_postgresql_flexible_server.civiform.administrator_login}&password=${azurerm_postgresql_flexible_server.civiform.administrator_password}&sslmode=require"

--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_public_ip" "public_ip" {
   location            = var.resource_group_location
   resource_group_name = var.resource_group_name
   # Standard SKUs (like what staging uses) requires Static allocation
-  allocation_method   = "Static"
+  allocation_method = "Static"
 }
 # prevent all access to the bastion's public IP address, but then in script 
 # set it up so that the current machine can access the public ip 

--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -39,7 +39,8 @@ resource "azurerm_public_ip" "public_ip" {
   name                = "${var.resource_group_name}-ip"
   location            = var.resource_group_location
   resource_group_name = var.resource_group_name
-  allocation_method   = "Dynamic"
+  # Standard SKUs (like what staging uses) requires Static allocation
+  allocation_method   = "Static"
 }
 # prevent all access to the bastion's public IP address, but then in script 
 # set it up so that the current machine can access the public ip 

--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
   features {}
+  # https://github.com/civiform/civiform/issues/8598
   subscription_id = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
 }

--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,4 +1,4 @@
 provider "azurerm" {
   features {}
-  subscription_id = var.azure_subscription
+  subscription_id = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
 }

--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,4 +1,4 @@
 provider "azurerm" {
   features {}
-  subscription_id = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
+  subscription_id = var.azure_subscription
 }

--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,3 +1,4 @@
 provider "azurerm" {
   features {}
+  subscription_id = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
 }

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -9,6 +9,11 @@ variable "azure_resource_group" {
   description = "Name of the resource group where key vault is already created."
 }
 
+variable "azure_subscription" {
+ type        = string
+ description = "Azure subscription id for where the resources should be created."
+}
+
 variable "civiform_time_zone_id" {
   type        = string
   description = "Time zone for Civiform server to use when displaying dates."

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -9,11 +9,6 @@ variable "azure_resource_group" {
   description = "Name of the resource group where key vault is already created."
 }
 
-variable "azure_subscription" {
-  type        = string
-  description = "Azure subscription id for where the resources should be created."
-}
-
 variable "civiform_time_zone_id" {
   type        = string
   description = "Time zone for Civiform server to use when displaying dates."

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -10,8 +10,9 @@ variable "azure_resource_group" {
 }
 
 variable "azure_subscription" {
- type        = string
- description = "Azure subscription id for where the resources should be created."
+  type        = string
+  description = "Azure subscription id for where the resources should be created."
+  default     = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
 }
 
 variable "civiform_time_zone_id" {

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -12,7 +12,6 @@ variable "azure_resource_group" {
 variable "azure_subscription" {
   type        = string
   description = "Azure subscription id for where the resources should be created."
-  default     = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
 }
 
 variable "civiform_time_zone_id" {


### PR DESCRIPTION
### Description

- providers need to include subscription id. This error didn't appear during my testing of the 4.1.0 update because it only occurs when the deployment setup changes.
- change private-ip allocation method to "Static"
  - the staging resource uses a standard SKU and "dynamic" allocation is only permissible for more expensive plans. It looks like "Static" just reserves an IP address and doesn't change it, not that I see a reason to change it after it's allocated. 
- remove `DOCKER_REGISTRY_SERVER_URL` 
  - this is now deprecated. The now preferred way of doing it is to set it in the linux_web_app resource, [which we are already doing](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/azure/modules/app/main.tf#L76). 
  allocation_method = "Static" 

### Checklist

#### General

- [x ] Added the correct label
- [x ] Assigned to a specific person or `civiform/deployment-system` 
- [x ] Created tests which fail without the change (if possible)
- [x ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ x] Extended the README / documentation, if necessary


