### PR TITLE
Remove unnecessary azurerm_app_service_virtual_network_swift_connection resource

### DIFF
--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -62,11 +62,6 @@ resource "azurerm_service_plan" "plan" {
   sku_name            = var.app_sku
 }
 
-resource "azurerm_app_service_virtual_network_swift_connection" "app_vn" {
-  app_service_id = azurerm_linux_web_app.civiform_app.id
-  subnet_id      = azurerm_subnet.server_subnet.id
-}
-
 resource "azurerm_linux_web_app" "civiform_app" {
   name                      = "${var.application_name}-${random_pet.server.id}"
   location                  = data.azurerm_resource_group.rg.location


### PR DESCRIPTION
### Description

We don't need this resource because we have the virtual_network_subnet_id set in the app resource.

### Checklist

#### General

- [x ] Added the correct label
- [x ] Assigned to a specific person or `civiform/deployment-system` 
- [x ] Created tests which fail without the change (if possible)
- [ x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

