### PR TITLE
Fix restoring from a snapshot

### DIFF
--- a/cloud/aws/bin/pgadmin.py
+++ b/cloud/aws/bin/pgadmin.py
@@ -112,7 +112,7 @@ def _print_connection_info(config, url):
         'To use the pgAdmin instance, you will need the pgadmin username, pgadmin password, and the PostgreSQL database password. Because these are sensitive values, you can either choose to print them here, or look them up yourself. To look them up, find the secret in AWS Secrets Manager, or run the "aws secretsmanager get-secret-value --secret-id=<secret name>" command. If you choose not to print them here, the name of the secret will be printed instead.\n'
     )
     answer = input(
-        'Would you like to print the pgadmin username and password? [y/N]> ')
+        'Would you like to print the pgadmin username and password? [y/N] > ')
     if answer.lower() in ['y', 'yes']:
         print(
             f"  pgAdmin login username: {cyan(aws.get_secret_value(pgadmin_username_secret))}\n"
@@ -123,7 +123,7 @@ def _print_connection_info(config, url):
             f"The name of the pgAdmin username secret is '{cyan(pgadmin_username_secret)}' and the pgAdmin password secret is '{cyan(pgadmin_password_secret)}'."
         )
 
-    answer = input('Would you like to print the database password? [y/N]> ')
+    answer = input('Would you like to print the database password? [y/N] > ')
     if answer.lower() in ['y', 'yes']:
         print(
             f"  PostgreSQL database password: {cyan(aws.get_secret_value(database_password_secret))}"

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -337,7 +337,7 @@ moved {
 
 module "ecs-autoscaling" {
   source  = "cn-terraform/ecs-service-autoscaling/aws"
-  version = "1.0.9"
+  version = "1.0.10"
 
   name_prefix               = local.name_prefix
   ecs_cluster_name          = var.ecs_cluster_name

--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -17,6 +17,7 @@ ADMIN_OIDC_CLIENT_ID = 'civiform_admin_oidc_client_id'
 ADMIN_OIDC_CLIENT_SECRET = 'civiform_admin_oidc_client_secret'
 ESRI_ARCGIS_API_TOKEN_SECRET = 'civiform_esri_arcgis_api_token'
 POSTGRES_PASSWORD = 'civiform_postgres_password'
+POSTGRES_USERNAME = 'civiform_postgres_username'
 
 # Defined in cloud/aws/templates/aws_oidc/main.tf
 DATABASE = 'civiform-db'

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -27,6 +27,29 @@ resource "aws_db_parameter_group" "civiform" {
   }
 }
 
+# When a snapshot is provided, if that snapshot came from a different CiviForm instance,
+# (e.g. we are doing bin/setup with a provided snapshot), it will be encrypted with a 
+# different KMS key. We need to copy the snapshot, re-encrypting it with the key used
+# for this instance, before aws_db_instance can then go ahead and deploy the database
+# from that snapshot.
+#
+# When we are restoring the database via bin/deploy into the same CiviForm instance,
+# this step ends up being redundant. But we can't check that the keys match in a 
+# bin/setup situation where the key does not yet exist. So we always copy the snapshot,
+# even if we don't need to.
+
+data "aws_db_snapshot" "snapshot" {
+  count                  = var.postgres_restore_snapshot_identifier == null ? 0 : 1
+  db_snapshot_identifier = var.postgres_restore_snapshot_identifier
+}
+
+resource "aws_db_snapshot_copy" "copied_snapshot" {
+  count                         = var.postgres_restore_snapshot_identifier == null ? 0 : 1
+  target_db_snapshot_identifier = "${var.app_prefix}-${var.postgres_restore_snapshot_identifier}-copied-snapshot"
+  source_db_snapshot_identifier = var.postgres_restore_snapshot_identifier
+  kms_key_id                    = aws_kms_key.civiform_kms_key.arn
+}
+
 resource "aws_db_instance" "civiform" {
   identifier = "${var.app_prefix}-${var.postgress_name}-db"
   tags = {
@@ -37,7 +60,7 @@ resource "aws_db_instance" "civiform" {
   apply_immediately = var.apply_database_changes_immediately
 
   # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
-  snapshot_identifier             = var.postgres_restore_snapshot_identifier
+  snapshot_identifier             = var.postgres_restore_snapshot_identifier == null ? null : aws_db_snapshot_copy.copied_snapshot[0].target_db_snapshot_identifier
   deletion_protection             = local.deletion_protection
   instance_class                  = var.postgres_instance_class
   allocated_storage               = var.postgres_storage_gb
@@ -63,6 +86,13 @@ resource "aws_db_instance" "civiform" {
   performance_insights_enabled    = var.rds_performance_insights_enabled
   monitoring_role_arn             = var.rds_enhanced_monitoring_enabled ? aws_iam_role.civiform_enhanced_monitoring_role[0].arn : null
   monitoring_interval             = var.rds_enhanced_monitoring_enabled ? var.rds_enhanced_monitoring_interval : null
+
+  lifecycle {
+    ignore_changes = [
+      username,
+      password,
+    ]
+  }
 }
 
 # Provide database information for other resources (pgadmin, for example).

--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -89,7 +89,7 @@ def run(config: ConfigLoader, params: List[str]):
                 are in use by another deployment. You should verify that no other deployments 
                 are using these resources before proceeding.
 
-                Would you like to destroy the backend resources and recreate them? [y/N] >
+                Would you like to destroy the backend resources and recreate them? [y/N] > 
                 """)
             answer = input(msg)
             if answer in ['y', 'Y', 'yes']:
@@ -102,7 +102,7 @@ def run(config: ConfigLoader, params: List[str]):
                         and running `bin/run destroy_backend_state_resources`. If the script continues to fail,
                         you may need to manually delete the resources in your cloud provider's console.
                         
-                        Would you like to continue anyway? [y/N] >
+                        Would you like to continue anyway? [y/N] > 
                         """)
                     answer = input(msg)
                     if answer not in ['y', 'Y', 'yes']:


### PR DESCRIPTION
When we restore from a snapshot, Terraform applies the temporary
database password to the restored database, rather than using the actual
database password as applied after the Terraform setup finishes (we do
this so we don't store the actual password in Terraform state). This reads the actual
password for the database from the secret and applies it when restoring.

While the code supports doing a bin/deploy with a snapshot identified
(that is, destroying your current database and restoring from a snapshot
in-place), we've decided to disable this code path for now until we get
a more imperative system for restoring from a snapshot in place in order
to avoid accidental data loss.

In a workflow where you want to set up a separate instance with a
different app_prefix, but based on a snapshot from the old app_prefix,
during bin/setup, this prompts the user to load the secret value from the previous
app_prefix, or to enter the password manually.

Additionally, when we are standing up a brand new CiviForm instance
based on a snapshot from another deployment, that snapshot is encrypted
with the KMS key from the old deployment. This results in Terraform
wanting to destroy the database and recreate it again on the next
deploy. Instead, we now copy the snapshot and re-encrypt it with the new
instance's key, then deploy the new database from that snapshot. A
subsequent deploy with POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER removed will
remove that copy.

Finally, this updates ecs-service-autoscaling to 1.0.10 to squash a bug
that caused it to always add 'null' into alarm action lists.

Fixes https://github.com/civiform/civiform/issues/8085
