### PR TITLE
Replace colon with hyphen in snapshot copy name

### DIFF
--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -45,7 +45,7 @@ data "aws_db_snapshot" "snapshot" {
 
 resource "aws_db_snapshot_copy" "copied_snapshot" {
   count                         = var.postgres_restore_snapshot_identifier == null ? 0 : 1
-  target_db_snapshot_identifier = "${var.app_prefix}-${var.postgres_restore_snapshot_identifier}-copied-snapshot"
+  target_db_snapshot_identifier = "${var.app_prefix}-${replace(var.postgres_restore_snapshot_identifier, ":", "-")}-copied-snapshot"
   source_db_snapshot_identifier = var.postgres_restore_snapshot_identifier
   kms_key_id                    = aws_kms_key.civiform_kms_key.arn
 }


### PR DESCRIPTION
Automated RDS snapshots are prefixed with "rds:". However, only those
automated snapshots are allowed to be called this, so when we create the
copy of the snapshot for use in a new deployment, replace the colon with
a hyphen.

Because AWS is, shall we say, "special", it can only contain letters,
digits and hyphens, and can't contain two consecutive hyphens or end in a
hyphen for reasons surpassing understanding. We don't guard against that
here since the source snapshot name has to be created with those
restrictions as well.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/8830
