### PR TITLE
Allow an optional cert file to be specified that gets used by pip

### DIFF
--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -34,7 +34,7 @@ function initialize_python_env() {
   # If a certificate file is specified, perform checks then configure pip to use it
   if [[ -n "$cert_file_path" ]]; then
     # Check if the file exists and is readable
-    if [[ ! -r "$cert_file_path" ]]; then
+    if [[ ! -f "$cert_file_path" || ! -r "$cert_file_path" ]]; then
       echo "Error: Certificate file '$cert_file_path' does not exist or is not readable."
       return 1
     fi

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -40,7 +40,7 @@ function initialize_python_env() {
     fi
 
     # Check the file format is PEM
-    if ! file "$cert_file_path" | grep -q "PEM certificate"; then 
+    if ! file "$cert_file_path" | grep -q "PEM certificate"; then
       echo "Error: Certificate file '$cert_file_path' is not in the correct format (expected PEM)."
       return 1
     fi

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -14,6 +14,7 @@ function initialize_python_env() {
   echo "initializing python env from script"
 
   local requirements_file_path=$1
+  local cert_file_path=$2
 
   # Check if there are any requirements to install
   if [[ ! -f "$requirements_file_path" ]]; then
@@ -25,6 +26,12 @@ function initialize_python_env() {
   if [[ ! -d .venv ]]; then
     echo ".venv directory not found, creating and installing dependencies..."
     python3 -m venv .venv
+  fi
+
+  # If a certificate file is specified, configure pip to use it
+  if [[ -n "$cert_file_path" ]]; then
+    echo "Setting pip global.cert to $cert_file_path"
+    pip config set global.cert "$cert_file_path"
   fi
 
   # source the activate script (. is more portable between shells than source)

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -34,7 +34,7 @@ function initialize_python_env() {
   # If a certificate file is specified, configure pip to use it
   if [[ -n "$cert_file_path" ]]; then
     echo "Setting pip global.cert to $cert_file_path"
-    pip3 config set global.cert "$cert_file_path"
+    pip config set global.cert "$cert_file_path"
   fi
 
   #Check if the requirement file is already met.

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -28,14 +28,14 @@ function initialize_python_env() {
     python3 -m venv .venv
   fi
 
+  # source the activate script (. is more portable between shells than source)
+  . .venv/bin/activate
+
   # If a certificate file is specified, configure pip to use it
   if [[ -n "$cert_file_path" ]]; then
     echo "Setting pip global.cert to $cert_file_path"
     pip config set global.cert "$cert_file_path"
   fi
-
-  # source the activate script (. is more portable between shells than source)
-  . .venv/bin/activate
 
   #Check if the requirement file is already met.
   if [[ ! $(pip3 freeze | diff "$requirements_file_path" -) ]]; then

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -39,12 +39,6 @@ function initialize_python_env() {
       return 1
     fi
 
-    # Check the file format is PEM
-    if ! file "$cert_file_path" | grep -q "PEM certificate"; then
-      echo "Error: Certificate file '$cert_file_path' is not in the correct format (expected PEM)."
-      return 1
-    fi
-
     echo "Setting pip global.cert to $cert_file_path"
     pip config set global.cert "$cert_file_path"
   fi

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -31,8 +31,20 @@ function initialize_python_env() {
   # source the activate script (. is more portable between shells than source)
   . .venv/bin/activate
 
-  # If a certificate file is specified, configure pip to use it
+  # If a certificate file is specified, perform checks then configure pip to use it
   if [[ -n "$cert_file_path" ]]; then
+    # Check if the file exists and is readable
+    if [[ ! -r "$cert_file_path" ]]; then
+      echo "Error: Certificate file '$cert_file_path' does not exist or is not readable."
+      return 1
+    fi
+
+    # Check the file format is PEM
+    if ! file "$cert_file_path" | grep -q "PEM certificate"; then 
+      echo "Error: Certificate file '$cert_file_path' is not in the correct format (expected PEM)."
+      return 1
+    fi
+
     echo "Setting pip global.cert to $cert_file_path"
     pip config set global.cert "$cert_file_path"
   fi

--- a/cloud/shared/bin/python_env_setup
+++ b/cloud/shared/bin/python_env_setup
@@ -34,7 +34,7 @@ function initialize_python_env() {
   # If a certificate file is specified, configure pip to use it
   if [[ -n "$cert_file_path" ]]; then
     echo "Setting pip global.cert to $cert_file_path"
-    pip config set global.cert "$cert_file_path"
+    pip3 config set global.cert "$cert_file_path"
   fi
 
   #Check if the requirement file is already met.

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -30,6 +30,24 @@ while getopts s:c:t:u:d:p: flag; do
   esac
 done
 
+# Validate the cert file, if provided
+if [[ -n "$cert_file_path" ]]; then
+  # Check if the cert file exists and is readable
+  if [[ -f "$cert_file_path" && -r "$cert_file_path" ]]; then
+    echo "Certificate file '$cert_file_path' exists and is readable."
+  else
+    echo "Certificate file '$cert_file_path' does not exist or is not readable."
+    exit 1
+  fi
+
+  # Check if it's a PEM file
+  file "$cert_file_path" | grep -q "PEM certificate"
+  if [[ $? -ne 0 ]]; then
+    echo "Certificate file '$cert_file_path' is not a PEM file."
+    exit 1
+  fi
+fi
+
 # if the tag is "latest", resolve it to the specific snapshot tag from Docker
 # Go templating is used to parse the snapshot tag from the json returned by docker inspect
 # https://docs.docker.com/engine/reference/commandline/inspect/#options

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -17,7 +17,7 @@ set -o pipefail
 source cloud/shared/bin/python_env_setup
 
 # Get the arguments that we want to pass to run.py
-while getopts s:c:t:u:d: flag; do
+while getopts s:c:t:u:d:p: flag; do
   case "${flag}" in
     # The civiform_config file that contains the values to configure the deployment
     s) source_config=${OPTARG} ;;
@@ -25,6 +25,8 @@ while getopts s:c:t:u:d: flag; do
     c) command=${OPTARG} ;;
     # The tag of the image that should be used for this deployment (e.g. "latest")
     t) tag=${OPTARG} ;;
+    # A custom trusted root CA file to set pip global config
+    p) cert_file_path=${OPTARG} ;;
   esac
 done
 
@@ -111,7 +113,7 @@ dependencies_file_path="cloud/shared/bin/env-var-docs-python-dependencies.txt"
 echo "env-var-docs @ git+https://github.com/civiform/civiform.git@${commit_sha}\
 #subdirectory=env-var-docs/parser-package" >>$dependencies_file_path
 
-initialize_python_env $dependencies_file_path
+initialize_python_env $dependencies_file_path "$cert_file_path"
 
 args=("--command" "${command}" "--tag" "${tag}" "--config" "${source_config}")
 

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -40,10 +40,11 @@ if [[ -n "$cert_file_path" ]]; then
     exit 1
   fi
 
-  # Check if it's a PEM file
-  file "$cert_file_path" | grep -q "PEM certificate"
-  if [[ $? -ne 0 ]]; then
-    echo "Certificate file '$cert_file_path' is not a PEM file."
+  # Check if it's a valid certificate
+  if file "$cert_file_path" | grep -q -E "PEM certificate|certificate"; then 
+    echo "Certificate file '$cert_file_path' is a valid certificate."
+  else
+    echo "Certificate file '$cert_file_path' is not a valid certificate."
     exit 1
   fi
 fi

--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -40,13 +40,6 @@ if [[ -n "$cert_file_path" ]]; then
     exit 1
   fi
 
-  # Check if it's a valid certificate
-  if file "$cert_file_path" | grep -q -E "PEM certificate|certificate"; then 
-    echo "Certificate file '$cert_file_path' is a valid certificate."
-  else
-    echo "Certificate file '$cert_file_path' is not a valid certificate."
-    exit 1
-  fi
 fi
 
 # if the tag is "latest", resolve it to the specific snapshot tag from Docker


### PR DESCRIPTION
### Description

Charlotte had a new firewall rule installed, which caused an error during deployment: `SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate`.

With this PR, we now allow a cert file to be specified. This also involved a change in their deployment repo, similar to [this](https://github.com/civiform/civiform-deploy/compare/clt-python?expand=1).

Charlotte tested this change and it fixed their issue and allowed them to deploy successfully.

### Checklist

#### General

- [x] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/8943
