### PR TITLE
Add ability to skip provider registrations for the terraform azure provider.

### DIFF
--- a/cloud/azure/main.tf
+++ b/cloud/azure/main.tf
@@ -13,4 +13,6 @@ terraform {
 
 provider "azurerm" {
   features {}
+
+  skip_provider_registration = var.azure_skip_provider_registration
 }

--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,6 +1,6 @@
 provider "azurerm" {
   features {}
   # https://github.com/civiform/civiform/issues/8598
-  subscription_id = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
+  subscription_id            = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
   skip_provider_registration = var.azure_skip_provider_registration
 }

--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -2,4 +2,5 @@ provider "azurerm" {
   features {}
   # https://github.com/civiform/civiform/issues/8598
   subscription_id = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
+  skip_provider_registration = var.azure_skip_provider_registration
 }

--- a/cloud/azure/templates/azure_saml_ses/variable_definitions.json
+++ b/cloud/azure/templates/azure_saml_ses/variable_definitions.json
@@ -113,7 +113,7 @@
     "type": "string"
   },
   "AZURE_SKIP_PROVIDER_REGISTRATION": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": true,
     "type": "bool"

--- a/cloud/azure/templates/azure_saml_ses/variable_definitions.json
+++ b/cloud/azure/templates/azure_saml_ses/variable_definitions.json
@@ -112,6 +112,12 @@
     "tfvar": false,
     "type": "string"
   },
+  "AZURE_SKIP_PROVIDER_REGISTRATION": {
+    "required": true,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
   "KEY_VAULT_NAME": {
     "required": true,
     "secret": false,

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -9,6 +9,12 @@ variable "azure_resource_group" {
   description = "Name of the resource group where key vault is already created."
 }
 
+variable "azure_skip_provider_registration" {
+  type        = bool
+  description = "Whether to skip provider registrations on azure, useful when using a principal with limited permissions."
+  default     = false
+}
+
 variable "civiform_time_zone_id" {
   type        = string
   description = "Time zone for Civiform server to use when displaying dates."


### PR DESCRIPTION
### Description

Only affects AZURE deployments.

Will configure the azurerm TF provider to skip_provider_registrations when the variable AZURE_SKIP_PROVIDER_REGISTRATION is set to "true".

The variable is defaulted to "false" and set as optional.

Tested by deploying onto azure.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

Ran the azure deployment script. -- Documentation for AZURE deployments is in progress.
