### PR TITLE
Upgrade azure provider version

### DIFF
--- a/cloud/azure/main.tf
+++ b/cloud/azure/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "azurerm"
-      version = ">=2.65"
+      version = "4.6.0"
     }
     random = {}
   }


### PR DESCRIPTION
### Description

We're having an issue with skip_provider_registration. This azure provider is different than https://github.com/civiform/cloud-deploy-infra/blob/c569edf4b4e8ea21ecf0cb776419a996efe9d5d5/cloud/azure/templates/azure_saml_ses/main.tf#L9, so updating for consistency

Also, Miami Dade is having issues that seem related to https://github.com/hashicorp/terraform-provider-azurerm/issues/27466, which should be fixed in the more recent versions of azurerm

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9153
