### PR TITLE
Update azure env var AZURE_STORAGE_ACCOUNT_CONTAINER  to AZURE_STORAGE_ACCOUNT_CONTAINER_NAME

### DIFF
--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -25,8 +25,8 @@ locals {
 
     STORAGE_SERVICE_NAME = "azure-blob"
 
-    AZURE_STORAGE_ACCOUNT_NAME      = azurerm_storage_account.files_storage_account.name
-    AZURE_STORAGE_ACCOUNT_CONTAINER = azurerm_storage_container.files_container.name
+    AZURE_STORAGE_ACCOUNT_NAME           = azurerm_storage_account.files_storage_account.name
+    AZURE_STORAGE_ACCOUNT_CONTAINER_NAME = azurerm_storage_container.files_container.name
 
     AWS_ACCESS_KEY_ID     = data.azurerm_key_vault_secret.aws_access_key_id.value
     AWS_SECRET_ACCESS_KEY = data.azurerm_key_vault_secret.aws_secret_access_token.value


### PR DESCRIPTION
### Description

Will be submitted after PR https://github.com/civiform/civiform/pull/9234  is merged.

That PR changes the name of the azure container env var for private files.

### Checklist

#### General

- [x] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

