### PR TITLE
Create variable for email provider

### DIFF
--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -277,7 +277,7 @@ variable "staging_ti_notification_mailing_list" {
 variable "email_provider" {
   type        = string
   description = "The provider to use for sending emails"
-  default     = "aws_ses"
+  default     = "aws-ses"
 }
 
 variable "sender_email_address" {

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -274,6 +274,12 @@ variable "staging_ti_notification_mailing_list" {
   default     = null
 }
 
+variable "email_provider" {
+  type        = string
+  description = "The provider to use for sending emails"
+  default     = "aws_ses"
+}
+
 variable "sender_email_address" {
   type        = string
   description = "Email address that emails will be sent from"

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -60,6 +60,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "email_provider" {
+  type        = string
+  description = "The provider to use for sending emails"
+  default     = "aws_ses"
+}
+
 variable "sender_email_address" {
   type        = string
   description = "Email address that emails will be sent from"

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -63,7 +63,6 @@ variable "aws_region" {
 variable "email_provider" {
   type        = string
   description = "The provider to use for sending emails"
-  default     = "aws_ses"
 }
 
 variable "sender_email_address" {

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -38,6 +38,12 @@
     "tfvar": true,
     "type": "string"
   },
+  "EMAIL_PROVIDER": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "SENDER_EMAIL_ADDRESS": {
     "required": true,
     "secret": false,


### PR DESCRIPTION
### Description

This will be used so we can conditionally create AWS resources based on this variable (see https://github.com/civiform/cloud-deploy-infra/pull/420)

I think for azure we'll eventually use graph-api as the default, but since that isn't supported, I left it empty for now

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9258
