### PR TITLE
Have Terraform create the public-files container for program card images for Azure deployments

### DIFF
--- a/cloud/azure/modules/app/file-storage.tf
+++ b/cloud/azure/modules/app/file-storage.tf
@@ -20,8 +20,14 @@ resource "azurerm_storage_account" "files_storage_account" {
 
 resource "azurerm_storage_container" "files_container" {
   name                  = "files"
-  storage_account_name  = azurerm_storage_account.files_storage_account.name
+  storage_account_id    = azurerm_storage_account.files_storage_account.id
   container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "public_files_container" {
+  name                  = "public-files"
+  storage_account_id    = azurerm_storage_account.files_storage_account.id
+  container_access_type = "blob"
 }
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "blob_storage_backup_policy" {

--- a/cloud/azure/modules/app/file-storage.tf
+++ b/cloud/azure/modules/app/file-storage.tf
@@ -15,7 +15,7 @@ resource "azurerm_storage_account" "files_storage_account" {
   # https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy
   account_replication_type = "LRS"
 
-  allow_nested_items_to_be_public = false
+  allow_nested_items_to_be_public = true
 }
 
 resource "azurerm_storage_container" "files_container" {

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -25,8 +25,9 @@ locals {
 
     STORAGE_SERVICE_NAME = "azure-blob"
 
-    AZURE_STORAGE_ACCOUNT_NAME           = azurerm_storage_account.files_storage_account.name
-    AZURE_STORAGE_ACCOUNT_CONTAINER_NAME = azurerm_storage_container.files_container.name
+    AZURE_STORAGE_ACCOUNT_NAME                  = azurerm_storage_account.files_storage_account.name
+    AZURE_STORAGE_ACCOUNT_CONTAINER_NAME        = azurerm_storage_container.files_container.name
+    AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME = azurerm_storage_container.public_files_container.name
 
     AWS_ACCESS_KEY_ID     = data.azurerm_key_vault_secret.aws_access_key_id.value
     AWS_SECRET_ACCESS_KEY = data.azurerm_key_vault_secret.aws_secret_access_token.value


### PR DESCRIPTION
### Description

Adds resource creation of the public-files container for program card images in Azure.

Tested manually by deploying to Azure and verifying that a public-files container exists in the default storage-account.

Civiform can't write these files yet, so that testing will be done when the functionality is added to Civiform.

### Checklist

#### General

- [X] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

