### PR TITLE
call lower() on a user response before comparing to 'y' or 'yes'

### DIFF
--- a/cloud/shared/bin/setup.py
+++ b/cloud/shared/bin/setup.py
@@ -48,7 +48,7 @@ def run(config: ConfigLoader, params: List[str]):
             Would you like to continue with the setup? [y/N] > 
             """)
         answer = input(msg)
-        if answer not in ['y', 'Y', 'yes']:
+        if answer.lower() not in ['y', 'yes']:
             exit(1)
     secret_length = config.get_config_var("RANDOM_PASSWORD_LENGTH")
     if not secret_length:
@@ -92,7 +92,7 @@ def run(config: ConfigLoader, params: List[str]):
                 Would you like to destroy the backend resources and recreate them? [y/N] > 
                 """)
             answer = input(msg)
-            if answer in ['y', 'Y', 'yes']:
+            if answer.lower() in ['y', 'yes']:
                 destroy.run(config, [])
                 if not template_setup.destroy_backend_resources(resources):
                     msg = inspect.cleandoc(


### PR DESCRIPTION
### Description

Compare responses in low string, like we do in most other places.

### Checklist

#### General

- [X] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [X] Created tests which fail without the change (if possible)
- [X] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [X] Extended the README / documentation, if necessary

