### PR TITLE
Remove hard-coded exigy subscription id from deployment terraform for Azure

### DIFF
--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,6 +1,5 @@
 provider "azurerm" {
   features {}
   # https://github.com/civiform/civiform/issues/8598
-  subscription_id            = "4ef4ae1b-c966-4ac4-9b7c-a837ea410821"
   skip_provider_registration = var.azure_skip_provider_registration
 }


### PR DESCRIPTION
### Description

This variable should not have a value set.

### Checklist

#### General

- [X] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [X] Created tests which fail without the change (if possible)
- [X] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [X] Extended the README / documentation, if necessary

### Issue(s) this completes

Fixes #9428
