### PR TITLE
Reference the environment variable for AZURE subscription ID

### DIFF
--- a/cloud/azure/templates/azure_saml_ses/providers.tf
+++ b/cloud/azure/templates/azure_saml_ses/providers.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
   features {}
   # https://github.com/civiform/civiform/issues/8598
+  subscription_id            = var.azure_subscription
   skip_provider_registration = var.azure_skip_provider_registration
 }


### PR DESCRIPTION

### Description

the subscription id is needed in, and should be retrieved from the environment variable.

### Checklist

#### General

- [X] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [X] Extended the README / documentation, if necessary

