### PR TITLE
azure_subscription needs to be defined as a TF var before its referenced.

### DIFF
--- a/cloud/azure/templates/azure_saml_ses/variable_definitions.json
+++ b/cloud/azure/templates/azure_saml_ses/variable_definitions.json
@@ -109,7 +109,7 @@
   "AZURE_SUBSCRIPTION": {
     "required": true,
     "secret": false,
-    "tfvar": false,
+    "tfvar": true,
     "type": "string"
   },
   "AZURE_SKIP_PROVIDER_REGISTRATION": {

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -15,6 +15,12 @@ variable "azure_skip_provider_registration" {
   default     = false
 }
 
+variable "azure_subscription" {
+  type        = string
+  description = "The azure subscription id to deploy onto."
+  default     = ""
+}
+
 variable "civiform_time_zone_id" {
   type        = string
   description = "Time zone for Civiform server to use when displaying dates."


### PR DESCRIPTION
### Description

Prior fix to add a reference to subscription neglected to add the tf var definition.

This fixes that problem, and has been tested in an azure deployment.

### Checklist

#### General

- [X] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [X] Created tests which fail without the change (if possible)
- [X] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [X] Extended the README / documentation, if necessary

