### PR TITLE
fix e2e test

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-e2e-aws-oidc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     # Makes it so only one instance of this workflow can run at a time:
     # https://docs.github.com/en/actions/using-jobs/using-concurrency
     concurrency: run-e2e-aws-oidc

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-e2e-aws-oidc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Makes it so only one instance of this workflow can run at a time:
     # https://docs.github.com/en/actions/using-jobs/using-concurrency
     concurrency: run-e2e-aws-oidc
@@ -83,8 +83,11 @@ jobs:
         if: always()
         uses: slackapi/slack-github-action@v2
         with:
-          channel-id:  'C03UXPUEXU4'
-          slack-message: "${{ env.STATUS_ICON }} AWS e2e test: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
+          method: chat.postMessage
+          token: ${{ secrets.CIVIBOT_TOKEN }}
+          payload: |
+            channel: ${{ env.CHANNEL_ID }}
+            text: "${{ env.STATUS_ICON }} AWS e2e test: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.CIVIBOT_TOKEN }}
+          CHANNEL_ID: C03UXPUEXU4
           STATUS_ICON: ${{fromJSON('[":no_entry:", ":white_check_mark:"]')[job.status == 'success']}}

--- a/e2e-test/nuke.yaml
+++ b/e2e-test/nuke.yaml
@@ -17,11 +17,17 @@ blocklist:
 resource-types:
   excludes:
     - AppStreamImage
+    - Cloud9Environment
     - CloudSearchDomain
     - CodeStarProject
+    - CodeStarConnection
+    - CodeStarNotification
     - ElasticacheCacheParameterGroup
+    - ElasticTranscoderPipeline
+    - ElasticTranscoderPreset
     - FMSNotificationChannel
     - FMSPolicy
+    - GuardDutyDetector
     - MachineLearningBranchPrediction
     - MachineLearningDataSource
     - MachineLearningEvaluation
@@ -34,7 +40,18 @@ resource-types:
     - OpsWorksLayer
     - OpsWorksUserProfile
     - OSPackage
+    - RedshiftServerlessSnapshot
+    - RedshiftServerlessNamespace
+    - RedshiftServerlessWorkgroup
     - ResourceExplorer2Index
+    - RoboMakerDeploymentJob
+    - RoboMakerFleet
+    - RoboMakerRobot
+    - RoboMakerSimulationJob
+    - RoboMakerSimulationApplication
+    - RoboMakerRobotApplication
+    - ServiceCatalogTagOption
+    - ServiceCatalogTagOptionPortfolioAttachment
 
 accounts:
   "296877675213": # civiform-deploy-e2e-tests AWS account.


### PR DESCRIPTION
### Description

The e2e test has been failing because of the recent upgrade to `slack-github-action@v2` and needed updates to the nuke.yaml. This PR fixes those things and successfully runs the e2e test when manually running the action. The action has been failing in recent weeks as an "Unknown Event" (https://github.com/civiform/cloud-deploy-infra/actions/runs/12577039084) so we'll have to see tonight if it successfully runs on the cron.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
