### PR TITLE
Allow port 80 listener to be disabled

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -192,6 +192,7 @@ moved {
 # AWS LOAD BALANCER - Listeners
 #------------------------------------------------------------------------------
 resource "aws_lb_listener" "lb_http_listeners" {
+  count             = var.enable_port_80_listener ? true : false
   load_balancer_arn = aws_lb.civiform_lb.arn
   port              = 80
   protocol          = "HTTP"

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -192,7 +192,7 @@ moved {
 # AWS LOAD BALANCER - Listeners
 #------------------------------------------------------------------------------
 resource "aws_lb_listener" "lb_http_listeners" {
-  count             = var.enable_port_80_listener ? true : false
+  count             = var.enable_port_80_listener ? 1 : 0
   load_balancer_arn = aws_lb.civiform_lb.arn
   port              = 80
   protocol          = "HTTP"

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -214,7 +214,7 @@ resource "aws_lb_listener" "lb_http_listeners" {
 
 moved {
   from = module.ecs-alb[0].aws_lb_listener.lb_http_listeners["default_http"]
-  to   = aws_lb_listener.lb_http_listeners
+  to   = var.enable_port_80_listener ? aws_lb_listener.lb_http_listeners[0] : null
 }
 
 resource "aws_lb_listener" "lb_https_listeners" {

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -214,7 +214,7 @@ resource "aws_lb_listener" "lb_http_listeners" {
 
 moved {
   from = module.ecs-alb[0].aws_lb_listener.lb_http_listeners["default_http"]
-  to   = var.enable_port_80_listener ? aws_lb_listener.lb_http_listeners[0] : null
+  to   = aws_lb_listener.lb_http_listeners[0]
 }
 
 resource "aws_lb_listener" "lb_https_listeners" {

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -214,7 +214,7 @@ resource "aws_lb_listener" "lb_http_listeners" {
 
 moved {
   from = module.ecs-alb[0].aws_lb_listener.lb_http_listeners["default_http"]
-  to   = aws_lb_listener.lb_http_listeners[0]
+  to   = aws_lb_listener.lb_http_listeners
 }
 
 resource "aws_lb_listener" "lb_https_listeners" {

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -110,7 +110,7 @@ moved {
 }
 
 resource "aws_security_group_rule" "ingress_through_http" {
-  count             = var.enable_port_80_listener ? 1 : 0
+  count             = var.enable_http_listener ? 1 : 0
   security_group_id = aws_security_group.lb_access_sg.id
   type              = "ingress"
   from_port         = 80
@@ -193,7 +193,7 @@ moved {
 # AWS LOAD BALANCER - Listeners
 #------------------------------------------------------------------------------
 resource "aws_lb_listener" "lb_http_listeners" {
-  count             = var.enable_port_80_listener ? 1 : 0
+  count             = var.enable_http_listener ? 1 : 0
   load_balancer_arn = aws_lb.civiform_lb.arn
   port              = 80
   protocol          = "HTTP"

--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -110,6 +110,7 @@ moved {
 }
 
 resource "aws_security_group_rule" "ingress_through_http" {
+  count             = var.enable_port_80_listener ? 1 : 0
   security_group_id = aws_security_group.lb_access_sg.id
   type              = "ingress"
   from_port         = 80

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -150,8 +150,8 @@ variable "extra_inbound_rule_cidr" {
   default     = null
 }
 
-variable "enable_port_80_listener" {
-  description = "Whether the load balancer listener on port 80 should be enabled. Defaulted to true"
+variable "enable_http_listener" {
+  description = "Whether the HTTP listener should be enabled. Defaulted to true."
   type        = bool
   default     = true
 }

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -149,3 +149,9 @@ variable "extra_inbound_rule_cidr" {
   type        = string
   default     = null
 }
+
+variable "enable_port_80_listener" {
+  description = "Whether the load balancer listener on port 80 should be enabled. Defaulted to true"
+  type        = bool
+  default     = true
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -336,6 +336,7 @@ module "ecs_fargate_service" {
   lb_internal               = local.enable_managed_vpc ? false : true
   lb_logging_enabled        = var.lb_logging_enabled
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
+  enable_port_80_listener   = var.enable_port_80_listener
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -336,7 +336,7 @@ module "ecs_fargate_service" {
   lb_internal               = local.enable_managed_vpc ? false : true
   lb_logging_enabled        = var.lb_logging_enabled
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
-  enable_port_80_listener   = var.enable_port_80_listener
+  enable_http_listener      = var.enable_http_listener
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -442,5 +442,11 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
-  }
+  },
+  "ENABLE_PORT_80_LISTENER": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  }  
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -443,7 +443,7 @@
     "tfvar": true,
     "type": "string"
   },
-  "ENABLE_PORT_80_LISTENER": {
+  "ENABLE_HTTP_LISTENER": {
     "required": false,
     "secret": false,
     "tfvar": true,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -556,8 +556,8 @@ variable "extra_inbound_rule_cidr" {
   default     = null
 }
 
-variable "enable_port_80_listener" {
-  description = "Whether the load balancer listener on port 80 should be enabled. Defaulted to true"
+variable "enable_http_listener" {
+  description = "Whether the HTTP listener should be enabled. Defaulted to true."
   type        = bool
   default     = true
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -555,3 +555,9 @@ variable "extra_inbound_rule_cidr" {
   type        = string
   default     = null
 }
+
+variable "enable_port_80_listener" {
+  description = "Whether the load balancer listener on port 80 should be enabled. Defaulted to true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
### Description

This is a change to allow the port 80 listener to be disabled. It defaults to enabled, which means nothing would change for existing deployments

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Tested on an existing deployment and see the message:

```
 # module.ecs_fargate_service.aws_lb_listener.lb_http_listeners will be destroyed
  # (because resource uses count or for_each)
  - resource "aws_lb_listener" "lb_http_listeners" {
      - arn               = "arn:aws:elasticloadbalancing:us-east-1:484539786037:listener/app/civiform-eng-civiform-lb/81602ccf4c6d6e67/b20038124635f3d2" -> null
      - id                = "arn:aws:elasticloadbalancing:us-east-1:484539786037:listener/app/civiform-eng-civiform-lb/81602ccf4c6d6e67/b20038124635f3d2" -> null
      - load_balancer_arn = "arn:aws:elasticloadbalancing:us-east-1:484539786037:loadbalancer/app/civiform-eng-civiform-lb/81602ccf4c6d6e67" -> null
      - port              = 80 -> null
      - protocol          = "HTTP" -> null
      - tags              = {
          - "Name" = "civiform-eng Civiform Fargate Service"
          - "Type" = "Civiform Fargate Service"
        } -> null
      - tags_all          = {
          - "Environment" = "staging"
          - "Group"       = "civiform-eng"
          - "Name"        = "civiform-eng Civiform Fargate Service"
          - "Service"     = "Civiform"
          - "Type"        = "Civiform Fargate Service"
        } -> null
        # (1 unchanged attribute hidden)

      - default_action {
          - order            = 1 -> null
          - type             = "redirect" -> null
            # (1 unchanged attribute hidden)

          - redirect {
              - host        = "#{host}" -> null
              - path        = "/#{path}" -> null
              - port        = "443" -> null
              - protocol    = "HTTPS" -> null
              - query       = "#{query}" -> null
              - status_code = "HTTP_301" -> null
            }
        }
    }

  # module.ecs_fargate_service.aws_lb_listener.lb_http_listeners[0] will be created
  + resource "aws_lb_listener" "lb_http_listeners" {
      + arn                      = (known after apply)
      + id                       = (known after apply)
      + load_balancer_arn        = "arn:aws:elasticloadbalancing:us-east-1:484539786037:loadbalancer/app/civiform-eng-civiform-lb/81602ccf4c6d6e67"
      + port                     = 80
      + protocol                 = "HTTP"
      + ssl_policy               = (known after apply)
      + tags                     = {
          + "Name" = "civiform-eng Civiform Fargate Service"
          + "Type" = "Civiform Fargate Service"
        }
      + tags_all                 = {
          + "Environment" = "staging"
          + "Group"       = "civiform-eng"
          + "Name"        = "civiform-eng Civiform Fargate Service"
          + "Service"     = "Civiform"
          + "Type"        = "Civiform Fargate Service"
        }
      + tcp_idle_timeout_seconds = (known after apply)

      + default_action {
          + order = (known after apply)
          + type  = "redirect"

          + redirect {
              + host        = "#{host}"
              + path        = "/#{path}"
              + port        = "443"
              + protocol    = "HTTPS"
              + query       = "#{query}"
              + status_code = "HTTP_301"
            }
        }

      + mutual_authentication (known after apply)
    }

```

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6975
