### PR TITLE
Update listener and listener rule to fix deployment

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -122,7 +122,7 @@ resource "aws_security_group_rule" "ingress_through_http" {
 
 moved {
   from = module.ecs-alb[0].aws_security_group_rule.ingress_through_http["default_http"]
-  to   = aws_security_group_rule.ingress_through_http
+  to   = aws_security_group_rule.ingress_through_http[0]
 }
 
 resource "aws_security_group_rule" "ingress_through_https" {
@@ -215,7 +215,7 @@ resource "aws_lb_listener" "lb_http_listeners" {
 
 moved {
   from = module.ecs-alb[0].aws_lb_listener.lb_http_listeners["default_http"]
-  to   = aws_lb_listener.lb_http_listeners
+  to   = aws_lb_listener.lb_http_listeners[0]
 }
 
 resource "aws_lb_listener" "lb_https_listeners" {


### PR DESCRIPTION
### Description

There was an issue finding the resource, since with the "count", the resource is [0]. See error:

Error: waiting for ELBv2 Listener (arn:aws:elasticloadbalancing:us-west-2:405662711265:listener/app/cf-test-civiform-lb/24d38790082d292e/b7ba689fcd4e2743) create: couldn't find resource
│ 
│   with module.ecs_fargate_service.aws_lb_listener.lb_http_listeners[0],
│   on ../../modules/ecs_fargate_service/main.tf line 195, in resource "aws_lb_listener" "lb_http_listeners":
│  195: resource "aws_lb_listener" "lb_http_listeners" {
│ 
╵

I've validated a successful deployment after this change:

```
Terraform will perform the following actions:

  # module.ecs_fargate_service.aws_lb_listener.lb_http_listeners will be destroyed
  # (because resource uses count or for_each)
  - resource "aws_lb_listener" "lb_http_listeners" {
      - arn               = "arn:aws:elasticloadbalancing:us-east-1:145023101365:listener/app/ns-civiform-lb/8b23283168d5b3dc/bc5646df912fdc23" -> null
      - id                = "arn:aws:elasticloadbalancing:us-east-1:145023101365:listener/app/ns-civiform-lb/8b23283168d5b3dc/bc5646df912fdc23" -> null
      - load_balancer_arn = "arn:aws:elasticloadbalancing:us-east-1:145023101365:loadbalancer/app/ns-civiform-lb/8b23283168d5b3dc" -> null
      - port              = 80 -> null
      - protocol          = "HTTP" -> null
      - tags              = {
          - "Name" = "ns Civiform Fargate Service"
          - "Type" = "Civiform Fargate Service"
        } -> null
      - tags_all          = {
          - "Environment" = "staging"
          - "Group"       = "ns"
          - "Name"        = "ns Civiform Fargate Service"
          - "Service"     = "Civiform"
          - "Type"        = "Civiform Fargate Service"
        } -> null
        # (1 unchanged attribute hidden)

      - default_action {
          - order            = 1 -> null
          - type             = "redirect" -> null
            # (1 unchanged attribute hidden)

          - redirect {
              - host        = "#{host}" -> null
              - path        = "/#{path}" -> null
              - port        = "443" -> null
              - protocol    = "HTTPS" -> null
              - query       = "#{query}" -> null
              - status_code = "HTTP_301" -> null
            }
        }
    }

  # module.ecs_fargate_service.aws_lb_listener.lb_http_listeners[0] will be created
  + resource "aws_lb_listener" "lb_http_listeners" {
      + arn                      = (known after apply)
      + id                       = (known after apply)
      + load_balancer_arn        = "arn:aws:elasticloadbalancing:us-east-1:145023101365:loadbalancer/app/ns-civiform-lb/8b23283168d5b3dc"
      + port                     = 80
      + protocol                 = "HTTP"
      + ssl_policy               = (known after apply)
      + tags                     = {
          + "Name" = "ns Civiform Fargate Service"
          + "Type" = "Civiform Fargate Service"
        }
      + tags_all                 = {
          + "Environment" = "staging"
          + "Group"       = "ns"
          + "Name"        = "ns Civiform Fargate Service"
          + "Service"     = "Civiform"
          + "Type"        = "Civiform Fargate Service"
        }
      + tcp_idle_timeout_seconds = (known after apply)

      + default_action {
          + order = (known after apply)
          + type  = "redirect"

          + redirect {
              + host        = "#{host}"
              + path        = "/#{path}"
              + port        = "443"
              + protocol    = "HTTPS"
              + query       = "#{query}"
              + status_code = "HTTP_301"
            }
        }

      + mutual_authentication (known after apply)
    }

  # module.ecs_fargate_service.aws_security_group_rule.ingress_through_http will be destroyed
  # (because resource uses count or for_each)
  - resource "aws_security_group_rule" "ingress_through_http" {
      - cidr_blocks            = [
          - "0.0.0.0/0",
        ] -> null
      - from_port              = 80 -> null
      - id                     = "sgrule-1277236713" -> null
      - prefix_list_ids        = [] -> null
      - protocol               = "tcp" -> null
      - security_group_id      = "sg-08ece8b59a6a5b653" -> null
      - security_group_rule_id = "sgr-067b3a47935ce7833" -> null
      - self                   = false -> null
      - to_port                = 80 -> null
      - type                   = "ingress" -> null
    }

  # module.ecs_fargate_service.aws_security_group_rule.ingress_through_http[0] will be created
  + resource "aws_security_group_rule" "ingress_through_http" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + from_port                = 80
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = "sg-08ece8b59a6a5b653"
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

Plan: 2 to add, 0 to change, 2 to destroy.

Warnings:

- Value for undeclared variable
- Argument is deprecated
  on main.tf line 124 (and 1 more)

To see the full warning notes, run Terraform without -compact-warnings.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.ecs_fargate_service.aws_lb_listener.lb_http_listeners: Destroying... [id=arn:aws:elasticloadbalancing:us-east-1:145023101365:listener/app/ns-civiform-lb/8b23283168d5b3dc/bc5646df912fdc23]
module.ecs_fargate_service.aws_security_group_rule.ingress_through_http: Destroying... [id=sgrule-1277236713]
module.ecs_fargate_service.aws_security_group_rule.ingress_through_http[0]: Creating...
module.ecs_fargate_service.aws_lb_listener.lb_http_listeners[0]: Creating...
module.ecs_fargate_service.aws_lb_listener.lb_http_listeners: Destruction complete after 0s
module.ecs_fargate_service.aws_lb_listener.lb_http_listeners[0]: Creation complete after 0s [id=arn:aws:elasticloadbalancing:us-east-1:145023101365:listener/app/ns-civiform-lb/8b23283168d5b3dc/e81f44b10fafed59]
module.ecs_fargate_service.aws_security_group_rule.ingress_through_http: Destruction complete after 0s
module.ecs_fargate_service.aws_security_group_rule.ingress_through_http[0]: Creation complete after 1s [id=sgrule-1277236713]

Apply complete! Resources: 2 added, 0 changed, 2 destroyed.

Waiting for CiviForm ECS service to become healthy.
Service URL: https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/ns-civiform/services/ns-civiform-service/deployments
Service is healthy.
Server is available at ns-civiform-lb-1581826670.us-east-1.elb.amazonaws.com. Check your domain registrar to ensure your CNAME record for https://ns.civiform.dev points to this address.
```


### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
