### PR TITLE
Remove reliance on AWS from the azure deployment

### DIFF
--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -12,8 +12,6 @@ locals {
   app_secret_key_keyvault_id      = "app-secret-key"
   api_secret_salt_key_keyvault_id = "api-secret-salt"
   adfs_secret_keyvault_id         = "adfs-secret"
-  aws_secret_access_token         = "aws-secret-access-token"
-  aws_access_key_id               = "aws-access-key-id"
 
   app_settings = merge({
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
@@ -28,9 +26,6 @@ locals {
     AZURE_STORAGE_ACCOUNT_NAME                  = azurerm_storage_account.files_storage_account.name
     AZURE_STORAGE_ACCOUNT_CONTAINER_NAME        = azurerm_storage_container.files_container.name
     AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME = azurerm_storage_container.public_files_container.name
-
-    AWS_ACCESS_KEY_ID     = data.azurerm_key_vault_secret.aws_access_key_id.value
-    AWS_SECRET_ACCESS_KEY = data.azurerm_key_vault_secret.aws_secret_access_token.value
 
     SECRET_KEY = data.azurerm_key_vault_secret.app_secret_key.value
 

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -27,6 +27,8 @@ locals {
     AZURE_STORAGE_ACCOUNT_CONTAINER_NAME        = azurerm_storage_container.files_container.name
     AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME = azurerm_storage_container.public_files_container.name
 
+    EMAIL_PROVIDER = "graph-api"
+
     SECRET_KEY = data.azurerm_key_vault_secret.app_secret_key.value
 
     ADFS_SECRET                  = data.azurerm_key_vault_secret.adfs_secret.value

--- a/cloud/azure/modules/app/secrets.tf
+++ b/cloud/azure/modules/app/secrets.tf
@@ -8,16 +8,6 @@ data "azurerm_key_vault_secret" "postgres_password" {
   key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
 }
 
-data "azurerm_key_vault_secret" "aws_secret_access_token" {
-  name         = local.aws_secret_access_token
-  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
-}
-
-data "azurerm_key_vault_secret" "aws_access_key_id" {
-  name         = local.aws_access_key_id
-  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
-}
-
 data "azurerm_key_vault_secret" "app_secret_key" {
   name         = local.app_secret_key_keyvault_id
   key_vault_id = data.azurerm_key_vault.civiform_key_vault.id

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -11,7 +11,7 @@ variable "application_name" {
 
 variable "aws_region" {
   type        = string
-  description = "Region for the aws account, if using"
+  description = "Region for the aws account. Azure support for AWS isn't supported (#9258), so this is unused"
   default     = "us-east-1"
 }
 

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -41,8 +41,6 @@ class Setup(SetupTemplate):
         self._setup_keyvault()
         print(" - Setting up the SAML keystore")
         self._setup_saml_keystore()
-        print(" - Setting up SES")
-        self._setup_ses()
         print(" - Finish Pre-Terraform setup.")
         return True
 
@@ -151,15 +149,3 @@ class Setup(SetupTemplate):
                 saml_keystore_storage_account
             ],
             check=True)
-
-    def _setup_ses(self):
-        if not self.key_vault_name:
-            raise RuntimeError("Key Vault Setup Required")
-        aws_username = self.config.get_config_var("AWS_USERNAME")
-        # fails silently for now. AWS setup not required for azure deployment.
-        subprocess.run(
-            [
-                "cloud/azure/bin/ses-to-keyvault", "-v", self.key_vault_name,
-                "-u", aws_username
-            ],
-            check=False)

--- a/cloud/azure/templates/azure_saml_ses/variable_definitions.json
+++ b/cloud/azure/templates/azure_saml_ses/variable_definitions.json
@@ -6,7 +6,7 @@
     "type": "string"
   },
   "AWS_USERNAME": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": false,
     "type": "string"

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -62,14 +62,14 @@ variable "key_vault_name" {
 
 variable "aws_region" {
   type        = string
-  description = "Region where the AWS servers will live"
+  description = "Region where the AWS servers will live. Azure support for AWS isn't supported (#9258), so this is unused"
   default     = "us-east-1"
 }
 
 variable "email_provider" {
   type        = string
   description = "The provider to use for sending emails"
-  default     = "aws-ses"
+  default     = "graph-api"
 }
 
 variable "sender_email_address" {


### PR DESCRIPTION
### Description

We previously relied on AWS from the Azure deployment for email sending, but we're replacing that with Graph API, since that is what Miami Dade would like to use and they're currently the only deployment on azure. In the future, we can add back AWS support if needed, but conditionally creating resources is not straightforward, so it didn't seem worth investing in that right now. Got sign off on this from the eng team in our weekly meeting.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
