### PR TITLE
Change default LB policy

### DIFF
--- a/cloud/aws/bin/pgadmin.py
+++ b/cloud/aws/bin/pgadmin.py
@@ -27,7 +27,7 @@ def run(config: ConfigLoader):
 
     url = f"{config.get_base_url()}:4433"
     print(
-        "\npgadmin terraform deployment finished. Waiting for pgadmin to be available (some request failures are expected). Press ctlr-c to shortcut this wait and print connection information."
+        f"\npgadmin terraform deployment finished. Waiting for pgadmin to be available at {url} (some request failures are expected). Press Ctrl-c to shortcut this wait and print connection information."
     )
     _wait_for_pgadmin_response(url)
     _print_connection_info(config, url)

--- a/cloud/aws/modules/pgadmin/main.tf
+++ b/cloud/aws/modules/pgadmin/main.tf
@@ -17,7 +17,7 @@ resource "aws_lb_listener" "pgadmin" {
   port              = 4433
   protocol          = "HTTPS"
   certificate_arn   = var.lb_ssl_cert_arn
-  ssl_policy        = "ELBSecurityPolicy-2016-08" # Default policy.
+  ssl_policy        = var.lb_ssl_policy
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.pgadmin.arn

--- a/cloud/aws/modules/pgadmin/variables.tf
+++ b/cloud/aws/modules/pgadmin/variables.tf
@@ -79,3 +79,8 @@ variable "secrets_recovery_window_in_days" {
   type        = string
   description = "Recovery window for secrets"
 }
+variable "lb_ssl_policy" {
+  description = "The AWS security policy to use on the load balancer. https://docs.aws.amazon.com/elasticloadbalancing/latest/network/describe-ssl-policies.html"
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -316,7 +316,7 @@ module "ecs_fargate_service" {
   app_prefix                = var.app_prefix
   desired_count             = var.fargate_desired_task_count
   default_certificate_arn   = var.ssl_certificate_arn
-  ssl_policy                = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  ssl_policy                = var.lb_ssl_policy
   vpc_id                    = local.vpc_id
   task_definition_arn       = var.monitoring_stack_enabled ? aws_ecs_task_definition.civiform_with_monitoring.arn : aws_ecs_task_definition.civiform_only.arn
   container_name            = "${var.app_prefix}-civiform"

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -192,6 +192,7 @@ module "pgadmin" {
   vpc_id          = local.vpc_id
   lb_arn          = module.ecs_fargate_service.aws_lb_civiform_lb_arn
   lb_ssl_cert_arn = var.ssl_certificate_arn
+  lb_ssl_policy   = var.lb_ssl_policy
   lb_access_sg_id = module.ecs_fargate_service.aws_security_group_lb_access_sg_id
   cidr_allowlist  = var.pgadmin_cidr_allowlist
 

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -448,5 +448,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
-  }  
+  },
+  "LB_SSL_POLICY": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -561,3 +561,9 @@ variable "enable_http_listener" {
   type        = bool
   default     = true
 }
+
+variable "lb_ssl_policy" {
+  description = "The AWS security policy to use on the load balancer. https://docs.aws.amazon.com/elasticloadbalancing/latest/network/describe-ssl-policies.html"
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}


### PR DESCRIPTION
This sets the default Load Balancer policy to
ELBSecurityPolicy-TLS13-1-2-2021-06, which allows TLSv1.3 and 1.2. This is the recommended policy. See
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html for details on all the policies.

In fact, clients were still able to connect via TLSv1.3 due to changes in the ALB applied last year. https://aws.amazon.com/about-aws/whats-new/2023/03/application-load-balancer-tls-1-3/

This policy ensures that connections between the ALB and the server is also TLSv1.3 or 1.2.  This is somewhat less important since it is all internal to the VPC, but a good idea nonetheless.

This also updates the ALB policy when setting up pgadmin.

Finally, this exposes the security policy as a variable so it can be overriden if needed.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

### Instructions for manual testing

Once deployed, do `curl -vv https://<your instance>/` to ensure it is connect with TLSv1.3 (although that should happen without this change too).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6730
