### PR TITLE
Expose LB timeout as a variable

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -56,7 +56,7 @@ resource "aws_lb" "civiform_lb" {
   load_balancer_type               = "application"
   drop_invalid_header_fields       = false
   subnets                          = var.public_subnets
-  idle_timeout                     = 60
+  idle_timeout                     = var.lb_idle_timeout
   enable_deletion_protection       = false
   enable_cross_zone_load_balancing = false
   enable_http2                     = true

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -155,3 +155,9 @@ variable "enable_http_listener" {
   type        = bool
   default     = true
 }
+
+variable "lb_idle_timeout" {
+  description = "Time in seconds that the connection is allowed to be idle."
+  type        = number
+  default     = 120
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -334,6 +334,7 @@ module "ecs_fargate_service" {
   scale_target_min_capacity = var.ecs_scale_target_min_capacity
   https_target_port         = var.port
   lb_internal               = local.enable_managed_vpc ? false : true
+  lb_idle_timeout           = var.lb_idle_timeout
   lb_logging_enabled        = var.lb_logging_enabled
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
   enable_http_listener      = var.enable_http_listener

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -431,6 +431,12 @@
     "tfvar": true,
     "type": "bool"
   },
+  "LB_IDLE_TIMEOUT": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "integer"
+  },
   "LB_LOGGING_ENABLED": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -544,6 +544,12 @@ variable "external_vpc_public_subnet_ids" {
   default     = []
 }
 
+variable "lb_idle_timeout" {
+  description = "Time in seconds that the connection is allowed to be idle. If the CiviForm server takes longer than this to respond (e.g. when compiling an export), the request will return a 504 Gateway error."
+  type        = number
+  default     = 120
+}
+
 variable "lb_logging_enabled" {
   type        = bool
   description = "Whether to enable LB access logging."


### PR DESCRIPTION
If the CiviForm server fails to respond to a request before the timeout, the user ends up getting a 504 Gateway error. This can happen currently when doing an export that takes more than 60 seconds to compile. This change lets you override the default, and changes the default to 2 minutes.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

Set LB_IDLE_TIMEOUT in your config and verify that Terraform changes the value accordingly.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9947
