### PR TITLE
Fix name of docker image for azure

### DIFF
--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -72,7 +72,7 @@ resource "azurerm_linux_web_app" "civiform_app" {
 
   site_config {
     application_stack {
-      docker_image_name   = var.image_tag
+      docker_image_name   = "${var.civiform_image_repo}:${var.image_tag}"
       docker_registry_url = "https://index.docker.io"
     }
   }

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -15,6 +15,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "civiform_image_repo" {
+  type        = string
+  description = "Dockerhub repository with Civiform images"
+  default     = "civiform/civiform"
+}
+
 variable "image_tag" {
   type        = string
   description = "Tag for container image"


### PR DESCRIPTION
### Description

This PR adds the `civiform/civiform` prefix that was missing from the docker image when deploying with Azure. It follows the same pattern we use for [AWS deploys](https://github.com/civiform/cloud-deploy-infra/blob/65157756919dd750424137f66ab4e8458ed139af/cloud/aws/templates/aws_oidc/app.tf#L37).

I tested this by deploying with Azure locally and making sure the deployment succeeded with the correct image.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary (Full docs on how to develop with Azure to come)

### Instructions for manual testing

Deploy Azure using this branch

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/9343
