### PR TITLE
Strip regex from Azure STORAGE_ACCOUNT_NAME

### DIFF
--- a/cloud/azure/bin/setup_tf_shared_state
+++ b/cloud/azure/bin/setup_tf_shared_state
@@ -22,8 +22,11 @@ fi
 readonly BACKEND_VARS_FILENAME="${1}"
 
 RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP}"
-# We use the first 15 characters of the resource group, since there is a limit to the storage account name length
-STORAGE_ACCOUNT_NAME="${AZURE_RESOURCE_GROUP:0:15}${RANDOM}"
+
+# We use the first 15 characters of the resource group and strip all non-alphanumeric 
+# characters to match restrictions on the storage account name
+FORMATTED_AZURE_RESOURCE_GROUP=$(echo "${AZURE_RESOURCE_GROUP:0:15}" | sed 's/[^[:alnum:]]//g')
+STORAGE_ACCOUNT_NAME="${FORMATTED_AZURE_RESOURCE_GROUP}${RANDOM}"
 CONTAINER_NAME="tfstate"
 
 echo "Check for Resource Group"


### PR DESCRIPTION
### Description

Storage account names must only contain alphanumeric characters. This PR strips all non-alphanumeric characters from the storage account name to allow for the auto-generation to pass the requirements. A follow-up PR will make sure all letters are lower case, which is another requirement for Azure.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)

