### PR TITLE
Shorten resource group name and strip non-alphanumeric characters

### DIFF
--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -1,7 +1,7 @@
 locals {
   # We use the first 15 characters of the resource group and strip all non-alphanumeric
   # characters to match restrictions on resource naming
-  formatted_resource_group_name = regex_replace(substr(var.resource_group_name, 0, 15), "[^a-zA-Z0-9]", "")
+  replace(substr(var.resource_group_name, 0, 15), "[^a-zA-Z0-9]", "")
 }
 
 # Make sure the bastion is within the vnet of the database

--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -1,7 +1,7 @@
 locals {
   # We use the first 15 characters of the resource group and strip all non-alphanumeric
   # characters to match restrictions on resource naming
-  replace(substr(var.resource_group_name, 0, 15), "[^a-zA-Z0-9]", "")
+  formatted_resource_group_name = replace(substr(var.resource_group_name, 0, 15), "[^a-zA-Z0-9]", "")
 }
 
 # Make sure the bastion is within the vnet of the database

--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -1,7 +1,7 @@
 locals {
   # We use the first 15 characters of the resource group and strip all non-alphanumeric
   # characters to match restrictions on resource naming
-  formatted_resource_group_name = $(echo "${var.resource_group_name:0:15}" | sed 's/[^[:alnum:]]//g')
+  formatted_resource_group_name = regex_replace(substr(var.resource_group_name, 0, 15), "[^a-zA-Z0-9]", "")
 }
 
 # Make sure the bastion is within the vnet of the database

--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -1,4 +1,6 @@
 locals {
+  # We use the first 15 characters of the resource group and strip all non-alphanumeric
+  # characters to match restrictions on resource naming
   formatted_resource_group_name = $(echo "${var.resource_group_name:0:15}" | sed 's/[^[:alnum:]]//g')
 }
 


### PR DESCRIPTION
### Description

Miami Dade got the following error when doing a deployment:

```
Error: unable to assume default computer name "computer_name" cannot contain the special characters: `\/"[]:|<>+=;,?*@&~!#$%^()_{}'` Please adjust the "name", or specify an explicit "computer_name"
│
│   with module.app.module.bastion.azurerm_linux_virtual_machine.bastion_vm,
│   on ../../modules/bastion/main.tf line 73, in resource "azurerm_linux_virtual_machine" "bastion_vm":
│   73: resource "azurerm_linux_virtual_machine" "bastion_vm" {
```

### Checklist

#### General

- [x] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9153
