### PR TITLE
Create a helper function to get the formatted name for bastion

### DIFF
--- a/cloud/azure/bin/lib/bastion.sh
+++ b/cloud/azure/bin/lib/bastion.sh
@@ -7,7 +7,7 @@
 #   1: the resource group name
 #######################################
 function get_formatted_name() {
-  echo "$(echo "${1:0:15}" | sed 's/[^[:alnum:]]//g')"
+  echo "${1:0:15}" | sed 's/[^[:alnum:]]//g'
 }
 
 #######################################

--- a/cloud/azure/bin/lib/bastion.sh
+++ b/cloud/azure/bin/lib/bastion.sh
@@ -1,6 +1,16 @@
 #! /usr/bin/env bash
 
 #######################################
+# Helper function to get the formatted name of the
+# resource group, which is alphanumeric only
+# Arguments:
+#   1: the resource group name
+#######################################
+function get_formatted_name() {
+  echo "$(echo "${1:0:15}" | sed 's/[^[:alnum:]]//g')"
+}
+
+#######################################
 # Get the ip for the bastion VM
 # Arguments:
 #   1: the resource group name
@@ -8,7 +18,7 @@
 function bastion::get_vm_ip() {
   az network public-ip show \
     -g "${1}" \
-    -n "${1}-ip" \
+    -n "$(get_formatted_name "$1")-ip" \
     --query "ipAddress" | tr -d '"'
 }
 
@@ -57,7 +67,7 @@ function bastion::update_bastion_ssh_keys() {
   az vm user update \
     -u adminuser \
     -g "${1}" \
-    -n "${1}-bstn-vm" \
+    -n "$(get_formatted_name "$1")-bstn-vm" \
     --ssh-key-value "$(<${2}.pub)"
 }
 
@@ -82,7 +92,7 @@ function bastion::allow_ip_security_group() {
   local MY_IPADDRESS=$(curl -s https://checkip.amazonaws.com)
   az network nsg rule update \
     -g "${1}" \
-    --nsg-name "${1}-pblc-nsg" \
+    --nsg-name "$(get_formatted_name "$1")-pblc-nsg" \
     -n "ssh-rule" \
     --access "Allow" \
     --source-address-prefixes "${MY_IPADDRESS}"
@@ -96,7 +106,7 @@ function bastion::allow_ip_security_group() {
 function bastion::deny_ip_security_group() {
   az network nsg rule update \
     -g "${1}" \
-    --nsg-name "${1}-pblc-nsg" \
+    --nsg-name "$(get_formatted_name "$1")-pblc-nsg" \
     -n "ssh-rule" \
     --access "Deny" \
     --source-address-prefixes "*"


### PR DESCRIPTION
### Description

Still getting the error:

│ Error: unable to assume default computer name "computer_name" cannot contain the special characters: `\/"[]:|<>+=;,?*@&~!#$%^()_{}'` Please adjust the "name", or specify an explicit "computer_name"

Realized this was another place we set the bastion name.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
