### PR TITLE
Changing AWS healthcheck path to '/programs'

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -162,7 +162,7 @@ resource "aws_lb_target_group" "lb_https_tgs" {
   health_check {
     enabled             = true
     interval            = 20
-    path                = "/playIndex"
+    path                = "/programs"
     protocol            = "HTTP"
     timeout             = 15
     healthy_threshold   = 2

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -109,7 +109,7 @@ module "civiform_server_container_def" {
   ]
 
   healthcheck = {
-    command     = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/playIndex --output-document - > /dev/null 2>&1"]
+    command     = ["CMD-SHELL", "wget --quiet http://127.0.0.1:${var.port}/programs --output-document - > /dev/null 2>&1"]
     interval    = 10
     timeout     = 30
     retries     = 5


### PR DESCRIPTION
### Description

Currently the `/playIndex` is being used as the healthcheck endpoint on AWS ECS tasks. This endpoint doesn't make any database calls so if the database is in a bad state the healthcheck is just like `tra la la, I'm happy and ok skipping in a park of daisies`.

Switching to using the `/programs` endpoint for now. This should let the task report a bad state so AWS will kill it and spin up another.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

