### PR TITLE
Enable restoring from a snapshot on deploy

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -16,16 +16,21 @@ def run(config: ConfigLoader):
         _check_application_secret_length(config, aws)
         _check_for_postgres_upgrade(config, aws)
 
-    # Even though the code supports it, for now, we are disallowing doing bin/deploy
-    # with a snapshot identified in order to prevent accidental data loss. When we move to
-    # a more imperative process for restoring from a snapshot, we can remove this block.
-    # Restoring from a snapshot via bin/setup is still allowed.
     if config.get_config_var('POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER'):
-        print(
-            red(
-                '!!! WARNING !!!: You are attempting to deploy with a snapshot restore identifier set. This is currently not allowed. Please remove the POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER from your config file and try again.'
-            ))
-        return
+        answer = input(
+            yellow(
+                """
+            ###########################################################################
+                                            WARNING                                                       
+            ###########################################################################
+            You are attempting to deploy with POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER set 
+            which will restore your database to a former snapshot and can result in data 
+            loss. 
+            
+            Do you wish to proceed? [y/N] > 
+            """))
+        if answer.lower() not in ['y', 'yes']:
+            exit(1)
     if not terraform.perform_apply(config):
         print('Terraform deployment failed.')
         # TODO(#2606): write and upload logs.


### PR DESCRIPTION
### Description

This PR re-enables allowing deployments to restore the db to a db snapshot on deploy (not just on setup). It adds a user input check to help guard against data loss from accidentally deploying with this value set.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary -- will do this soon! maybe [here](https://docs.civiform.us/it-manual/sre-playbook/disaster-recovery)

### Instructions for manual testing

1. Spin up a deployment and seed the database. Publish all programs.
2. Take a snapshot of the db in AWS
3. Clear the database via the developer tools
4. Set `export POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER=<snapshot name>` in your deployment config
5. Run `bin/deploy` and follow the prompts
6. Deployment should succeed and you should see data re-populated on your site again

### Issue(s) this completes

Slack thread with context: https://civiform.slack.com/archives/C044VUMJSSH/p1746624121481959
