### PR TITLE
Create a variable for CIDR block for sg ingress

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -116,7 +116,7 @@ resource "aws_security_group_rule" "ingress_through_http" {
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [var.ingress_sg_cidr]
   prefix_list_ids   = []
 }
 
@@ -131,7 +131,7 @@ resource "aws_security_group_rule" "ingress_through_https" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [var.ingress_sg_cidr]
   prefix_list_ids   = []
 }
 

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -150,6 +150,12 @@ variable "extra_inbound_rule_cidr" {
   default     = null
 }
 
+variable "ingress_sg_cidr" {
+  description = "The CIDR block for the ingress_through_http and ingress_through_https security groups. This defaults to '0.0.0.0/0' (allowing all traffic)."
+  type        = string
+  default     = null
+}
+
 variable "enable_http_listener" {
   description = "Whether the HTTP listener should be enabled. Defaulted to true."
   type        = bool

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -337,6 +337,7 @@ module "ecs_fargate_service" {
   lb_idle_timeout           = var.lb_idle_timeout
   lb_logging_enabled        = var.lb_logging_enabled
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
+  ingress_sg_cidr           = var.ingress_sg_cidr
   enable_http_listener      = var.enable_http_listener
 
   tags = {

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -449,6 +449,12 @@
     "tfvar": true,
     "type": "string"
   },
+  "INGRESS_SG_CIDR": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "ENABLE_HTTP_LISTENER": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -562,6 +562,12 @@ variable "extra_inbound_rule_cidr" {
   default     = null
 }
 
+variable "ingress_sg_cidr" {
+  description = "The CIDR block for the ingress_through_http and ingress_through_https security groups. This defaults to '0.0.0.0/0' (allowing all traffic)."
+  type        = string
+  default     = null
+}
+
 variable "enable_http_listener" {
   description = "Whether the HTTP listener should be enabled. Defaulted to true."
   type        = bool


### PR DESCRIPTION
### Description

There was a request to be able to lock down staging sites to a particular CIDR range

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
