### PR TITLE
Turn off delete_automated_backups

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -25,7 +25,8 @@ def run(config: ConfigLoader):
             ###########################################################################
             You are attempting to deploy with POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER set 
             which will restore your database to a former snapshot and can result in data 
-            loss. 
+            loss. We recommend taking a manual snapshot of the database before running 
+            this command.
             
             Do you wish to proceed? [y/N] > 
             """))

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -61,7 +61,7 @@ resource "aws_db_instance" "civiform" {
 
   # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
   snapshot_identifier             = var.postgres_restore_snapshot_identifier == null ? null : aws_db_snapshot_copy.copied_snapshot[0].target_db_snapshot_identifier
-  delete_automated_backups        = false
+  delete_automated_backups        = var.delete_automated_backups
   deletion_protection             = local.deletion_protection
   instance_class                  = var.postgres_instance_class
   allocated_storage               = var.postgres_storage_gb

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -61,6 +61,7 @@ resource "aws_db_instance" "civiform" {
 
   # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
   snapshot_identifier             = var.postgres_restore_snapshot_identifier == null ? null : aws_db_snapshot_copy.copied_snapshot[0].target_db_snapshot_identifier
+  delete_automated_backups        = false
   deletion_protection             = local.deletion_protection
   instance_class                  = var.postgres_instance_class
   allocated_storage               = var.postgres_storage_gb

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -61,7 +61,7 @@ resource "aws_db_instance" "civiform" {
 
   # If not null, destroys the current database, replacing it with a new one restored from the provided snapshot
   snapshot_identifier             = var.postgres_restore_snapshot_identifier == null ? null : aws_db_snapshot_copy.copied_snapshot[0].target_db_snapshot_identifier
-  delete_automated_backups        = var.delete_automated_backups
+  delete_automated_backups        = var.delete_automated_db_backups
   deletion_protection             = local.deletion_protection
   instance_class                  = var.postgres_instance_class
   allocated_storage               = var.postgres_storage_gb

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -454,5 +454,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "DELETE_AUTOMATED_BACKUPS": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }  
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -455,7 +455,7 @@
     "tfvar": true,
     "type": "bool"
   },
-  "DELETE_AUTOMATED_BACKUPS": {
+  "DELETE_AUTOMATED_DB_BACKUPS": {
     "required": false,
     "secret": false,
     "tfvar": true,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -567,3 +567,8 @@ variable "enable_http_listener" {
   type        = bool
   default     = true
 }
+variable "delete_automated_backups" {
+  description = "Whether Terrform should delete automatically generated snapshots when the db is destroyed."
+  type        = bool
+  default     = false
+}

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -567,7 +567,7 @@ variable "enable_http_listener" {
   type        = bool
   default     = true
 }
-variable "delete_automated_backups" {
+variable "delete_automated_db_backups" {
   description = "Whether Terrform should delete automatically generated snapshots when the db is destroyed."
   type        = bool
   default     = false


### PR DESCRIPTION
### Description

This PR adds a configurable variable `delete_automated_backups` that controls whether or not system/auto-generated snapshots will be deleted when the associated db is destroyed. We default this to `false` to override Terraform's default which automatically deletes system snapshots when the associated db is torn down. We allow this variable to be configurable so admin can allow system snapshots to be deleted if they want to.

We decided to make this change after attempting to restore a gov environment to a system snapshot only to have it deleted in the process.

Note: Manual snapshots are not deleted when the db is destroyed and are not affected by this change.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary (will update when I do the other docs updates)

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

I tested this in the following ways:
- `bin/setup` with neither `POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER` nor `DELETE_AUTOMATED_BACKUPS` (no effect)
- `bin/deploy` with neither `POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER` nor `DELETE_AUTOMATED_BACKUPS` (no effect)
- `bin/deploy` with `POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER` set to a snapshot and `DELETE_AUTOMATED_BACKUPS` not set (retains system snapshots)
- `bin/deploy` with `POSTGRES_RESTORE_SNAPSHOT_IDENTIFIER` set to a manual snapshot and `DELETE_AUTOMATED_BACKUPS` set to true (previous system snapshots are maintained, new ones are deleted if/when the db is torn down again)
