### PR TITLE
Allow for config not to have newline at the end

### DIFF
--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -49,6 +49,7 @@ jobs:
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
           curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh -H "Authorization: Bearer ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}" > civiform_config.sh
+          echo >> civiform_config.sh
           echo 'export CIVIFORM_MODE="test"' >> civiform_config.sh
           echo 'export USE_LOCAL_BACKEND=true' >> civiform_config.sh
 


### PR DESCRIPTION
When the staging config was updated and did not have a newline at the end, this would try to append the CIVIFORM_MODE setting to the end of that existing line. This adds a new line to ensure we never do that.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary
