### PR TITLE
Fix latest SHA lookup

### DIFF
--- a/cloud/shared/bin/run
+++ b/cloud/shared/bin/run
@@ -48,7 +48,7 @@ fi
 if [[ "${tag}" == "latest" ]]; then
   docker pull --platform linux/x86_64 docker.io/civiform/civiform:latest
   snapshot_tag="$(docker inspect docker.io/civiform/civiform:latest \
-    --format='{{range .Config.Env}}{{if eq (printf "%.19s" .) "CIVIFORM_IMAGE_TAG="}}{{slice . 19}}{{end}}{{end}}')"
+    --format='{{ index .Config.Labels "civiform.git.commit_sha" }}')"
 
   if [[ -z "${snapshot_tag}" ]]; then
     # Adding a newline before the error message helps it stand out to the user
@@ -85,7 +85,10 @@ function fetch_json_val() {
 
 commit_sha=""
 
-if [[ "${tag}" == "SNAPSHOT"* || "${tag}" == "DEV"* ]]; then
+if [[ "${tag}" =~ ^[0-9a-f]{40}$ ]]; then
+  # We have a long commit SHA. Pass on through.
+  commit_sha="${tag}"
+elif [[ "${tag}" == "SNAPSHOT"* || "${tag}" == "DEV"* ]]; then
   # In a snapshot tag, eg. "SNAPSHOT-920bc49-1685642238", the middle section is the
   # shortened commit sha. Use this to get the full commit sha.
   split_tag=(${tag//-/ })


### PR DESCRIPTION
### Description

If the short SHA used in the image name ever collided with another (which happened with 3d0ff45), GitHub would return a 422 response and say it can't find the SHA. This change pulls the civiform.git.commit_sha label out of the image in order to get the full commit SHA.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Current latest (3d0ff45) fails with the current system, passes with this one when you set CLOUD_DEPLOY_INFRA_REMOTE to a checkout of this branch.
