### PR TITLE
Carry Docker image tag through Azure deploy

### DIFF
--- a/cloud/azure/bin/deploy
+++ b/cloud/azure/bin/deploy
@@ -10,7 +10,7 @@ azure_log::fetch_log_file
 
 if ! terraform::perform_apply; then
   out::error "Terraform deployment failed."
-  log::deploy_failed "${IMAGE_TAG}" "${AZURE_USER_ID}"
+  log::deploy_failed "${TF_VAR_image_tag}" "${AZURE_USER_ID}"
   azure_log::upload_log_file
   exit 1
 fi
@@ -20,12 +20,12 @@ if civiform_mode::is_test; then
   exit 0
 fi
 
-azure::set_new_container_tag "${AZURE_RESOURCE_GROUP}" "${AZURE_APP_NAME}" "${IMAGE_TAG}"
+azure::set_new_container_tag "${AZURE_RESOURCE_GROUP}" "${AZURE_APP_NAME}" "${TF_VAR_image_tag}"
 
 if health::wait_for_success "${AZURE_PRIMARY_URL}/playIndex"; then
   echo "New container returns expected signal on ping"
 else
-  log::deploy_failed "${IMAGE_TAG}" "${AZURE_USER_ID}"
+  log::deploy_failed "${TF_VAR_image_tag}" "${AZURE_USER_ID}"
   azure_log::upload_log_file
   exit 1
 fi
@@ -33,6 +33,6 @@ fi
 echo "Success! The new application version is up and running."
 
 echo "Updating deployment log."
-log::deploy_succeeded "${IMAGE_TAG}" "${AZURE_USER_ID}"
+log::deploy_succeeded "${TF_VAR_image_tag}" "${AZURE_USER_ID}"
 azure_log::upload_log_file
 echo "Deployment log updated."


### PR DESCRIPTION
### Description

In https://github.com/civiform/cloud-deploy-infra/pull/457 we fixed the image tag so it's carried through during setup, but deploy remained broken. This PR fixes the Azure deploy flow so image tag is carried through there as well. 

`IMAGE_TAG` is an outdated var name that is no longer set in our config. `TF_VAR_image_tag` is now the var that is used to reference the image tag that is derived from the `CIVIFORM_VERSION` config var.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Setup an instance in Azure then deploy to that same instance and make sure the correct image tag shows up in Azure under the app service properties and that the site loads.
<img width="672" alt="image" src="https://github.com/user-attachments/assets/6fcdebbf-99ad-4c9e-8c61-b8740948f5f9" />



### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/8894
