### PR TITLE
Fix azure resource group name in deploy

### DIFF
--- a/cloud/azure/bin/setup_tf_shared_state
+++ b/cloud/azure/bin/setup_tf_shared_state
@@ -45,7 +45,8 @@ echo "Check storage accounts"
 CURRENT_ACCOUNTS=$(az storage account list \
   -g ${RESOURCE_GROUP_NAME})
 
-STORAGE_ACCOUNT_PATTERN="\"name\"\: \"(${AZURE_RESOURCE_GROUP}[0-9]+)\""
+STORAGE_ACCOUNT_PATTERN="\"name\"\: \"(${FORMATTED_AZURE_RESOURCE_GROUP}[0-9]+)\""
+
 if [[ $CURRENT_ACCOUNTS =~ $STORAGE_ACCOUNT_PATTERN ]]; then
   echo "You have a storage account already, using the name ${BASH_REMATCH[1]}"
   STORAGE_ACCOUNT_NAME=${BASH_REMATCH[1]}


### PR DESCRIPTION
### Description

Deploys with complex resource group names (names with non-alphanumeric characters, eg. `rocky_fine`) were failing because we now format resource group names to remove non-alphanumeric characters (eg. `rocky_fine` -> `rockyfine`) and use the formatted name to create resources. However, the deploy script was using the original resource group name instead of the formatted group name to check for the existence of the storage account, resulting in the existing storage account not being recognized and the deploy attempting to create a new storage account only to fail because one already existed in that resource group.

Note: This was not causing the deploy to fail on staging, because the original resource group name (`staging`) happens to only contain alphabetic characters and therefore matches the formatted name (`staging` -> `staging`).

Extra note: We really should have tests for this that test different resource group names. I made an issue for that: https://github.com/civiform/civiform/issues/10603

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Setup a deployment instance with a resource group name that contains non-alphanumeric characters. Deploy to that same instance and confirm existing resources are recognized and deployment succeeds.

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/8894
