### PR TITLE
Make azure deploy interactive

### DIFF
--- a/cloud/shared/bin/lib/terraform.sh
+++ b/cloud/shared/bin/lib/terraform.sh
@@ -2,7 +2,7 @@
 
 # https://www.baeldung.com/linux/store-command-in-variable
 readonly TERRAFORM_CMD=("terraform" "-chdir=${TERRAFORM_TEMPLATE_DIR}")
-readonly TERRAFORM_APPLY=(${TERRAFORM_CMD[@]} "apply" "-input=false" "-json")
+readonly TERRAFORM_APPLY=(${TERRAFORM_CMD[@]} "apply" "-input=false")
 
 #######################################
 # Destorys the terraform code


### PR DESCRIPTION
### Description

Removing `-json` allows the Azure terraform deploy to be interactive and prevents the need for setting `export SKIP_CONFIRMATIONS=true`.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Setup an Azure deployment instance. Deploy to that instance and confirm the deploy is interactive in the terminal and that it deploys successfully.

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/8894
