### PR TITLE
Fix Azure applicant auth and ensure config values get set correctly

### DIFF
--- a/cloud/azure/bin/setup-keyvault
+++ b/cloud/azure/bin/setup-keyvault
@@ -8,6 +8,8 @@ readonly API_SECRET_SALT_NAME="api-secret-salt"
 readonly ADFS_SECRET_NAME="adfs-secret"
 readonly ADFS_CLIENT_ID="adfs-client-id"
 readonly ADFS_DISCOVERY_URI="adfs-discovery-uri"
+readonly APPLICANT_OIDC_CLIENT_ID="applicant-oidc-client-id"
+readonly APPLICANT_OIDC_CLIENT_SECRET="applicant-oidc-client-secret"
 readonly TEMPORARY_SECRET="CHANGE ME"
 
 # DOC: Create key vault instance, set permissions, and generate and set secrets
@@ -89,11 +91,20 @@ else
     "${TEMPORARY_SECRET}"
 fi
 
-if key_vault::has_secret "${vault_name}" "${ADFS_DISCOVERY_URI}"; then
-  echo "Key ${ADFS_DISCOVERY_URI} exists in the secret store"
+if key_vault::has_secret "${vault_name}" "${APPLICANT_OIDC_CLIENT_ID}"; then
+  echo "Key ${APPLICANT_OIDC_CLIENT_ID} exists in the secret store"
 else
   key_vault::add_secret \
     "${vault_name}" \
-    "${ADFS_DISCOVERY_URI}" \
+    "${APPLICANT_OIDC_CLIENT_ID}" \
+    "${TEMPORARY_SECRET}"
+fi
+
+if key_vault::has_secret "${vault_name}" "${APPLICANT_OIDC_CLIENT_SECRET}"; then
+  echo "Key ${APPLICANT_OIDC_CLIENT_SECRET} exists in the secret store"
+else
+  key_vault::add_secret \
+    "${vault_name}" \
+    "${APPLICANT_OIDC_CLIENT_SECRET}" \
     "${TEMPORARY_SECRET}"
 fi

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -12,6 +12,9 @@ locals {
   app_secret_key_keyvault_id      = "app-secret-key"
   api_secret_salt_key_keyvault_id = "api-secret-salt"
   adfs_secret_keyvault_id         = "adfs-secret"
+  adfs_client_id                  = "adfs-client-id"
+  applicant_oidc_client_id        = "applicant-oidc-client-id"
+  applicant_oidc_client_secret    = "applicant-oidc-client-secret"
 
   app_settings = merge({
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
@@ -33,10 +36,8 @@ locals {
 
     ADFS_SECRET                  = data.azurerm_key_vault_secret.adfs_secret.value
     ADFS_CLIENT_ID               = data.azurerm_key_vault_secret.adfs_client_id.value
-    ADFS_DISCOVERY_URI           = data.azurerm_key_vault_secret.adfs_discovery_uri.value
-    APPLICANT_OIDC_CLIENT_SECRET = data.azurerm_key_vault_secret.adfs_secret.value
-    APPLICANT_OIDC_DISCOVERY_URI = data.azurerm_key_vault_secret.adfs_discovery_uri.value
-    APPLICANT_OIDC_CLIENT_ID     = data.azurerm_key_vault_secret.adfs_client_id.value
+    APPLICANT_OIDC_CLIENT_SECRET = data.azurerm_key_vault_secret.applicant_oidc_client_secret.value
+    APPLICANT_OIDC_CLIENT_ID     = data.azurerm_key_vault_secret.applicant_oidc_client_id.value
 
     # The values below are all defaulted to null. If SAML authentication is used, the values can be pulled from the
     # saml_keystore module
@@ -57,6 +58,4 @@ locals {
     # azure AD to not include that claim.
     ADFS_ADDITIONAL_SCOPES = ""
   }, var.civiform_server_environment_variables)
-  adfs_client_id     = "adfs-client-id"
-  adfs_discovery_uri = "adfs-discovery-uri"
 }

--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -28,11 +28,6 @@ data "azurerm_key_vault_secret" "adfs_client_id" {
   key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
 }
 
-data "azurerm_key_vault_secret" "adfs_discovery_uri" {
-  name         = local.adfs_discovery_uri
-  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
-}
-
 resource "azurerm_data_protection_backup_vault" "backup_vault" {
   name                = "backup-vault"
   resource_group_name = data.azurerm_resource_group.rg.name

--- a/cloud/azure/modules/app/secrets.tf
+++ b/cloud/azure/modules/app/secrets.tf
@@ -22,3 +22,13 @@ data "azurerm_key_vault_secret" "adfs_secret" {
   name         = local.adfs_secret_keyvault_id
   key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
 }
+
+data "azurerm_key_vault_secret" "applicant_oidc_client_id" {
+  name         = local.applicant_oidc_client_id
+  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
+}
+
+data "azurerm_key_vault_secret" "applicant_oidc_client_secret" {
+  name         = local.applicant_oidc_client_secret
+  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
+}

--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -43,6 +43,8 @@ module "app" {
   saml_keystore_storage_access_key     = module.saml_keystore.storage_access_key
   saml_keystore_storage_account_name   = module.saml_keystore.storage_account_name
   saml_keystore_storage_container_name = module.saml_keystore.storage_container_name
+
+  civiform_server_environment_variables = var.civiform_server_environment_variables
 }
 
 module "custom_hostname" {


### PR DESCRIPTION
### Description

Azure applicant authentication wasn't working and part of the reason was because the server config values weren't being passed through to azure. Ensured this works as expected by deploying azure staging and logging in.

Since we are picking up the config values, the discovery URI doesn't need to be set within the deployment, which was needed prior.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Deployed to staging with changes https://staging-azure.civiform.dev/

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/9785