### PR TITLE
Disable deployment env image

### DIFF
--- a/.github/workflows/push_deployment_env_image.yaml
+++ b/.github/workflows/push_deployment_env_image.yaml
@@ -1,9 +1,8 @@
+# Note: this was built to help in deploying on Windows, but we currently don't have Windows deployers, so we're disabling it for now.
+
 name: build_push_deployment_env_image
 
 on:
-  push:
-    branches:
-      - main
   # Setting this enables manually triggering workflow in the GitHub UI
   # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}


### PR DESCRIPTION
### Description

We no longer have windows deployers and this is no longer succeeding, so disabling this for now. It is still available for workflow dispatch and we can re-enable it if it is needed in the future. 

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
