### PR TITLE
feature: Add auto_confirm_sns_subscription flag for civiform_alert_subscription

### DIFF
--- a/cloud/aws/templates/aws_oidc/alarms.tf
+++ b/cloud/aws/templates/aws_oidc/alarms.tf
@@ -9,6 +9,7 @@ resource "aws_sns_topic_subscription" "civiform_alert_subscription" {
   topic_arn = aws_sns_topic.civiform_alert_topic[0].arn
   protocol  = "email"
   endpoint  = var.civiform_alarm_email
+  endpoint_auto_confirms = var.auto_confirm_sns_subscription
 }
 
 locals {

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -578,3 +578,8 @@ variable "delete_automated_db_backups" {
   type        = bool
   default     = false
 }
+variable "auto_confirm_sns_subscription" {
+  description = "Whether to auto-confirm SNS topic subscription automatically."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Description

This PR adds a new `auto_confirm_sns_subscription` flag to conditionally auto-confirm SNS email subscriptions using the `endpoint_auto_confirms` attribute in Terraform.

Specifically:

- Adds a new `auto_confirm_sns_subscription` boolean variable (default: `false`)
- Applies this flag to the `aws_sns_topic_subscription.civiform_alert_subscription` resource
- Removes previously deployed test Lambda resources for auto-confirmation
- Ran `terraform plan` with `auto_confirm_sns_subscription=true` to verify it triggers a `PendingConfirmation` subscription without errors

### Checklist

#### General

- [X] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [X] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing
In your Terraform plan command, pass in:
-var='auto_confirm_sns_subscription=true' \
-var='civiform_alarm_email="your-email@domain.com"'


### Issue(s) this completes

Fixes #10816
