### PR TITLE
feat: route ECS autoscaling CloudWatch alarms to civiform_alert SNS topic

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -357,6 +357,7 @@ module "ecs-autoscaling" {
   scale_target_max_capacity = var.scale_target_max_capacity
   scale_target_min_capacity = var.scale_target_min_capacity
   tags                      = var.tags
+  sns_topic_arn             = var.sns_topic_arn
 }
 
 moved {

--- a/cloud/aws/modules/ecs_fargate_service/variables.tf
+++ b/cloud/aws/modules/ecs_fargate_service/variables.tf
@@ -167,3 +167,9 @@ variable "lb_idle_timeout" {
   type        = number
   default     = 120
 }
+
+variable "sns_topic_arn" {
+  type        = string
+  default     = null
+  description = "Optional SNS topic ARN for ECS autoscaling alarms."
+}

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -339,6 +339,7 @@ module "ecs_fargate_service" {
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
   ingress_sg_cidr           = var.ingress_sg_cidr
   enable_http_listener      = var.enable_http_listener
+  sns_topic_arn             = aws_sns_topic.civiform_alert_topic[0].arn
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -339,7 +339,7 @@ module "ecs_fargate_service" {
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
   ingress_sg_cidr           = var.ingress_sg_cidr
   enable_http_listener      = var.enable_http_listener
-  sns_topic_arn             = aws_sns_topic.civiform_alert_topic[0].arn
+  sns_topic_arn             = length(aws_sns_topic.civiform_alert_topic) > 0 ? aws_sns_topic.civiform_alert_topic[0].arn : null
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"


### PR DESCRIPTION
This change wires the alert SNS topic ARN (civiform_alert_topic) into the ECS autoscaling module so that scaling alarms also trigger email alerts. This ensures that alarms tied to ECS CPU thresholds are surfaced alongside existing system alerts.

### Description
This PR updates the `app.tf` configuration to pass the shared `civiform_alert_topic` ARN into the ECS autoscaling module via the `sns_topic_arn` input. Previously, ECS CPU utilization alarms existed solely for autoscaling and did not notify the alert topic. With this change:

- ECS autoscaling alarms now publish to the same SNS topic used for system-wide alerts.
- Notification emails (e.g., low CPU) are delivered to the same endpoint configured in `civiform_alert_email`.

No changes were required in the `alarms.tf` module, as the topic was already being defined there.

 ### Release Notes
Improved visibility of ECS autoscaling events via alert emails

 - Autoscaling-related CloudWatch alarms (e.g. high/low ECS CPU utilization) are now wired to the existing `civiform_alert_topic` SNS topic.

 - This means deployment admins will begin receiving email alerts when the ECS service scales up or down.

 - To suppress these scaling alerts, you may unset the `CIVIFORM_ALARM_EMAIL` variable in your deployment config.

**Note for governments and partners:**
We’re surfacing these events to provide better observability, but welcome feedback if the signal-to-noise ratio is too high. In future releases we may offer a dedicated variable to filter or disable scaling alerts independently.


### Checklist

#### General

- [X] Added the correct label
- [X] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [X] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing
1. Set your `civiform_alert_email` to a valid email address.
2. From `civiform-staging-deploy`, make sure your `checkout.sh` references your feature branch that contains the change.
3. Run:
   ```bash
         bin/setup
         bin/deploy

In AWS Console:

4. Go to SNS > Topics and confirm a topic with name like *-civiform-alert-topic exists.

Check that a subscription is present and confirmed for your email.

Go to CloudWatch > Alarms and find the ECS autoscaling alarms (e.g., *-cpu-low).
5. Wait or simulate CPU load/drop to trigger a scaling alarm.
6. Confirm you receive an email from AWS for the alarm transition (e.g., ALARM state for low CPU usage).


### Issue(s) this completes

Fixes #10848
