### PR TITLE
 Add ECS_CREATE_AUTOSCALE_ALARM variable

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -339,7 +339,7 @@ module "ecs_fargate_service" {
   extra_inbound_rule_cidr   = var.extra_inbound_rule_cidr
   ingress_sg_cidr           = var.ingress_sg_cidr
   enable_http_listener      = var.enable_http_listener
-  sns_topic_arn             = length(aws_sns_topic.civiform_alert_topic) > 0 ? aws_sns_topic.civiform_alert_topic[0].arn : null
+  sns_topic_arn             = length(aws_sns_topic.civiform_alert_topic) > 0 && var.ecs_create_autoscale_alarm ? aws_sns_topic.civiform_alert_topic[0].arn : null
 
   tags = {
     Name = "${var.app_prefix} Civiform Fargate Service"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -369,6 +369,12 @@
     "tfvar": true,
     "type": "string"
   },
+  "ECS_CREATE_AUTOSCALE_ALARM": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
+  },
   "ECS_SCALE_TARGET_MAX_CAPACITY": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -451,6 +451,12 @@ variable "ecs_alarm_statistic_period" {
   default     = "60"
 }
 
+variable "ecs_create_autoscale_alarm" {
+  type        = bool
+  description = "Whether or not to create an SNS topic and alarm for autoscaling events."
+  default     = true
+}
+
 variable "ecs_scale_target_max_capacity" {
   type        = number
   description = "The max capacity of the scalable target."


### PR DESCRIPTION
### Description

This commit introduces a new boolean variable, `ECS_CREATE_AUTOSCALE_ALARM`, that controls whether an SNS topic is created for ECS autoscaling alarms.

The `sns_topic_arn` for the `ecs_fargate_service` will now only be set if `ECS_CREATE_AUTOSCALE_ALARM` is true and an SNS topic exists.

I decided to default this to true to mimic the behavior that currently exists and governments can opt out of these alerts. Also good with setting this to false. If https://github.com/cn-terraform/terraform-aws-ecs-service-autoscaling/pull/41 gets approved, we can update this to only alert on scale up events.

**Note** - this was created by Jules (I knew exactly what needed to be done, but it is slightly tedious to make the changes in both files and was curious if Jules could do it), with the following prompt: `right now, we set sns_topic_arn = length(aws_sns_topic.civiform_alert_topic) > 0 ? aws_sns_topic.civiform_alert_topic[0].arn : null for the ecs_fargate_service. Could we introduce a new variable ECS_CREATE_AUTOSCALE_ALARM which is a boolean variable that would also be checked before sns_topic_arn is set?` After, I looked closely at the change and tested it.

### Checklist

#### General

- [x] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Deployed using this branch without adding to config file and proceeded with no changes then deployed with `export ECS_CREATE_AUTOSCALE_ALARM=false`

Before with alarm:
<img width="1282" height="690" alt="Screenshot 2025-09-03 at 3 04 52 PM" src="https://github.com/user-attachments/assets/ab1af394-7d50-49da-a92a-cb334c51b4fb" />

Terraform message:
<img width="891" height="489" alt="Screenshot 2025-09-03 at 3 06 49 PM" src="https://github.com/user-attachments/assets/6577a1a8-4f6f-4f6b-a705-f444ae4cf577" />

After:
<img width="1264" height="711" alt="Screenshot 2025-09-03 at 3 07 17 PM" src="https://github.com/user-attachments/assets/e00972a1-5c5e-42fe-b415-095146725b58" />


### Issue(s) this completes

https://github.com/civiform/civiform/issues/11269
