### PR TITLE
Use new variable to only notify on scale up events

### DIFF
--- a/cloud/aws/modules/ecs_fargate_service/main.tf
+++ b/cloud/aws/modules/ecs_fargate_service/main.tf
@@ -343,7 +343,7 @@ moved {
 
 module "ecs-autoscaling" {
   source  = "cn-terraform/ecs-service-autoscaling/aws"
-  version = "1.0.10"
+  version = "1.0.11"
 
   name_prefix               = local.name_prefix
   ecs_cluster_name          = var.ecs_cluster_name
@@ -357,7 +357,7 @@ module "ecs-autoscaling" {
   scale_target_max_capacity = var.scale_target_max_capacity
   scale_target_min_capacity = var.scale_target_min_capacity
   tags                      = var.tags
-  sns_topic_arn             = var.sns_topic_arn
+  high_cpu_sns_topic_arn    = var.sns_topic_arn
 }
 
 moved {


### PR DESCRIPTION
### Description

I created a change in the autoscaling module that adds a new variable specifically for scale up events https://github.com/cn-terraform/terraform-aws-ecs-service-autoscaling/pull/41. Scale down events have been really noisy, so this allows us to specifically notify on scale up.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [x] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

Tested and saw that this only created an alarm for autoscaling up not down. 
<img width="984" height="545" alt="Screenshot 2025-09-04 at 9 52 02 AM" src="https://github.com/user-attachments/assets/a0622461-f041-42d1-8323-b3bec201eeee" />


### Issue(s) this completes

https://github.com/civiform/civiform/issues/11269
