### PR TITLE
remove oncall link

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -106,7 +106,6 @@ class AwsCli:
             """
             go to the Service URL printed above and click on the logs tab.
             More details at https://docs.civiform.us/it-manual/sre-playbook/terraform-deploy-system/terraform-aws-deployment#inspecting-logs
-            For debugging help, contact the CiviForm oncall: https://docs.civiform.us/governance-and-management/project-management/on-call-guide#on-call-responsibilities
             """)
 
         current_deployment_id = None


### PR DESCRIPTION
### Description

Removing the link to our on call docs since they are meant to be internal facing and were moved to our internal wiki. This also better reflects current practices because govs typically do not reach out to the on call engineer, but reach out generally via Slack or specifically to an engineer they have been working with.
### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/11433
