### PR TITLE
Use updated SSL cert in e2e account

### DIFF
--- a/e2e-test/civiform_config_aws_oidc.sh
+++ b/e2e-test/civiform_config_aws_oidc.sh
@@ -208,7 +208,7 @@ export APP_PREFIX="e2e-test" # max 19 chars, only numbers, letters, dashes, and 
 # in AWS web console: https://console.aws.amazon.com/acm/home#/certificates/list
 # WARNING: certificate needs to be created in the same region as AWS_REGION above, make sure
 # select correct region in web AWS console when creating certificate.
-export SSL_CERTIFICATE_ARN="arn:aws:acm:us-east-1:296877675213:certificate/23d76695-0c59-4774-aa0d-be708e9ca414"
+export SSL_CERTIFICATE_ARN="arn:aws:acm:us-east-1:296877675213:certificate/0d87a1aa-73b5-4b15-9b5e-d785137b5a8d"
 
 # REQUIRED
 # Number of Civiform server tasks to run. This value can be set to 0 to shutdown servers.


### PR DESCRIPTION
### Description

The current cert expired.  I created a new one: https://github.com/civiform/civiform/issues/11559#issuecomment-3325670556.

### Checklist

#### General

- [x] Added the correct label
- [x] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/11559