### PR TITLE
Disable azure renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,7 @@
       "description": "Ensures GitHub Actions use commit hashes for security and include a version comment."
     },
     // Disable updates for the azurerm Terraform provider because we don't currently support azure deployments
+    // TODO(#13129): Re-enable dependency updates when we continue azure support
     {
       "matchPackageNames": ["azurerm"],
       "matchManagers": ["terraform"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,12 @@
       "postUpdateOptions": ["comment"],
       "rebaseWhen": "always",
       "description": "Ensures GitHub Actions use commit hashes for security and include a version comment."
+    },
+    // Disable updates for the azurerm Terraform provider because we don't currently support azure deployments
+    {
+      "matchPackageNames": ["azurerm"],
+      "matchManagers": ["terraform"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### Description

Disables azure renovate updates.

### Checklist

#### General

- [ ] Added the correct label
- [ ] Assigned to a specific person or `civiform/deployment-system` 
- [ ] Created tests which fail without the change (if possible)
- [ ] Performed manual testing (at a minimum run `bin/setup` without your changes and then `bin/deploy` with your changes to ensure your changes don't break existing deployments)
- [ ] Extended the README / documentation, if necessary